### PR TITLE
Add auto OG/social cards: per-report unfurl meta at publish

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1149,6 +1149,103 @@ export function injectBadge(html) {
   return `${html}\n${tag}\n`;
 }
 
+// Default Open Graph card image — a Pagecast-branded card already hosted on the
+// landing site. Branded so every shared link carries Pagecast into the feed
+// (the pre-click half of the badge loop). Per-report dynamic cards are a future
+// enhancement; keep this a single constant so it's a one-line change.
+export const DEFAULT_OG_IMAGE = "https://pagecasthq.pages.dev/og-image.png";
+
+function escapeAttr(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// Decode the handful of entities a source document might already carry, so we
+// don't double-escape when re-emitting the text into a meta attribute.
+function decodeBasicEntities(value) {
+  return String(value)
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;|&apos;/gi, "'");
+}
+
+// Pull a human title from a document: prefer a meaningful <title>, else fall
+// back to the report's display name.
+export function extractTitle(html, fallback = "") {
+  const match = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(String(html || ""));
+  const title = match ? decodeBasicEntities(match[1].replace(/\s+/g, " ").trim()) : "";
+  const generic = /^(index|untitled|document|report)$/i;
+  if (title && !generic.test(title)) {
+    return title;
+  }
+  return String(fallback || title || "").trim();
+}
+
+// Pull a short description: prefer an existing meta description, else the first
+// paragraph's text, truncated. Returns "" when nothing usable is found.
+export function extractDescription(html) {
+  const doc = String(html || "");
+  const meta = /<meta[^>]+name=["']description["'][^>]*>/i.exec(doc);
+  if (meta) {
+    const content = /content=["']([\s\S]*?)["']/i.exec(meta[0]);
+    if (content && content[1].trim()) {
+      return decodeBasicEntities(content[1].replace(/\s+/g, " ").trim()).slice(0, 200);
+    }
+  }
+  const para = /<p[^>]*>([\s\S]*?)<\/p>/i.exec(doc);
+  if (para) {
+    const text = decodeBasicEntities(para[1].replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim());
+    if (text) {
+      return text.slice(0, 200);
+    }
+  }
+  return "";
+}
+
+// Inject Open Graph + Twitter card meta so shared links unfurl richly instead of
+// as bare URLs. Idempotent and non-clobbering: if the document already declares
+// its own og: meta, it's returned unchanged. `image`/`siteName` are only emitted
+// when provided (the caller gates Pagecast branding on the badge/white-label
+// setting). Pure + exported for testing.
+export function injectSocialMeta(html, { title, description, url, image, siteName } = {}) {
+  const doc = String(html || "");
+  if (/(?:property|name)=["']og:/i.test(doc)) {
+    return doc;
+  }
+  if (!title && !description && !url) {
+    return doc;
+  }
+  const tags = [];
+  const meta = (prop, content, attr = "property") => {
+    if (content) {
+      tags.push(`<meta ${attr}="${prop}" content="${escapeAttr(content)}">`);
+    }
+  };
+  meta("og:type", "article");
+  meta("og:title", title);
+  meta("og:description", description);
+  meta("og:url", url);
+  meta("og:image", image);
+  meta("og:site_name", siteName);
+  meta("twitter:card", "summary_large_image", "name");
+  meta("twitter:title", title, "name");
+  meta("twitter:description", description, "name");
+  meta("twitter:image", image, "name");
+  const block = tags.join("\n");
+  if (/<\/head>/i.test(doc)) {
+    return doc.replace(/<\/head>/i, `${block}\n</head>`);
+  }
+  if (/<body[^>]*>/i.test(doc)) {
+    return doc.replace(/<body[^>]*>/i, (bodyTag) => `${block}\n${bodyTag}`);
+  }
+  return `${block}\n${doc}`;
+}
+
 export function createCloudflarePagesPublisher({
   dataDir = path.join(PROJECT_ROOT, ".pagecast"),
   spawnImpl = spawn,
@@ -1224,7 +1321,7 @@ export function createCloudflarePagesPublisher({
     await fs.writeFile(routesPath, renderRoutesJson(manifest.map((entry) => entry.slug)), "utf8");
   }
 
-  async function stagePublication(report, publication) {
+  async function stagePublication(report, publication, { pagesBaseUrl = "" } = {}) {
     const slug = publication.slug || publication.token;
     const destinationRoot = publicationDir(slug);
     const sourceRoot = publishSourceFor(report);
@@ -1247,9 +1344,20 @@ export function createCloudflarePagesPublisher({
       html = injectFeedbackWidget(html, { url: feedback.url, slug });
     }
     // Inject the "Published with Pagecast" badge unless turned off (white-label).
-    if (getBadge()) {
+    const badgeOn = getBadge();
+    if (badgeOn) {
       html = injectBadge(html);
     }
+    // Inject Open Graph / Twitter meta so the shared link unfurls richly. The
+    // Pagecast-branded card image + site_name are gated on the badge setting, so
+    // white-label pages get clean per-report unfurls without Pagecast branding.
+    html = injectSocialMeta(html, {
+      title: extractTitle(html, report.name),
+      description: extractDescription(html),
+      url: pagesBaseUrl ? joinUrl(pagesBaseUrl, `/p/${encodeURIComponent(slug)}/`) : "",
+      image: badgeOn ? DEFAULT_OG_IMAGE : "",
+      siteName: badgeOn ? "Pagecast" : ""
+    });
     await fs.writeFile(indexPath, html, "utf8");
   }
 
@@ -1335,7 +1443,7 @@ export function createCloudflarePagesPublisher({
   async function publish({ report, publication, pagesConfig }) {
     const slug = publication.slug || publication.token;
     await ensureSiteRoot();
-    await stagePublication(report, publication);
+    await stagePublication(report, publication, { pagesBaseUrl: pagesConfig?.baseUrl });
     try {
       const baseUrl = await deploy(pagesConfig);
       return joinUrl(baseUrl, `/p/${encodeURIComponent(slug)}/`);
@@ -1351,7 +1459,7 @@ export function createCloudflarePagesPublisher({
   async function syncPublication({ report, publication, pagesConfig }) {
     const slug = publication.slug || publication.token;
     await ensureSiteRoot();
-    await stagePublication(report, publication);
+    await stagePublication(report, publication, { pagesBaseUrl: pagesConfig?.baseUrl });
     const baseUrl = await deploy(pagesConfig);
     return joinUrl(baseUrl, `/p/${encodeURIComponent(slug)}/`);
   }
@@ -1360,7 +1468,7 @@ export function createCloudflarePagesPublisher({
   // returning the new public URL.
   async function renamePublication({ oldSlug, newSlug, report, publication, pagesConfig }) {
     await ensureSiteRoot();
-    await stagePublication(report, { ...publication, slug: newSlug });
+    await stagePublication(report, { ...publication, slug: newSlug }, { pagesBaseUrl: pagesConfig?.baseUrl });
     if (oldSlug && oldSlug !== newSlug) {
       await removePublication(oldSlug);
     }

--- a/src/server.js
+++ b/src/server.js
@@ -1192,9 +1192,11 @@ export function extractDescription(html) {
   const doc = String(html || "");
   const meta = /<meta[^>]+name=["']description["'][^>]*>/i.exec(doc);
   if (meta) {
-    const content = /content=["']([\s\S]*?)["']/i.exec(meta[0]);
-    if (content && content[1].trim()) {
-      return decodeBasicEntities(content[1].replace(/\s+/g, " ").trim()).slice(0, 200);
+    // Backreference the opening quote (\1) so a value containing the other
+    // quote char — e.g. an apostrophe in "We're …" — isn't truncated early.
+    const content = /content=(["'])([\s\S]*?)\1/i.exec(meta[0]);
+    if (content && content[2].trim()) {
+      return decodeBasicEntities(content[2].replace(/\s+/g, " ").trim()).slice(0, 200);
     }
   }
   const para = /<p[^>]*>([\s\S]*?)<\/p>/i.exec(doc);

--- a/test/social-meta.test.js
+++ b/test/social-meta.test.js
@@ -78,6 +78,19 @@ test("extractDescription prefers meta description, else first paragraph text", (
   assert.equal(extractDescription("<div>no para here</div>"), "");
 });
 
+test("extractDescription keeps apostrophes (closing quote matches the opener)", () => {
+  // Regression for the bug Devin caught on PR #3: a double-quoted value with an
+  // apostrophe must not truncate at the apostrophe ("We" instead of "We're …").
+  assert.equal(
+    extractDescription('<meta name="description" content="We\'re up 18% this quarter">'),
+    "We're up 18% this quarter"
+  );
+  assert.equal(
+    extractDescription("<meta name='description' content='She said \"hi\" today'>"),
+    'She said "hi" today'
+  );
+});
+
 // --- integration: publish stages the OG block ------------------------------
 
 function fakeDeploySpawn(command, args, options) {

--- a/test/social-meta.test.js
+++ b/test/social-meta.test.js
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  DEFAULT_OG_IMAGE,
+  createCloudflarePagesPublisher,
+  createConfigStore,
+  createReportStore,
+  extractDescription,
+  extractTitle,
+  injectSocialMeta
+} from "../src/server.js";
+
+// --- unit: injectSocialMeta -------------------------------------------------
+
+test("injectSocialMeta adds OG + Twitter tags inside <head>", () => {
+  const html = "<!doctype html><html><head><title>X</title></head><body><h1>Hi</h1></body></html>";
+  const out = injectSocialMeta(html, {
+    title: "My Report",
+    description: "A summary",
+    url: "https://x.pages.dev/p/abc/",
+    image: "https://img/og.png",
+    siteName: "Pagecast"
+  });
+  assert.match(out, /<meta property="og:title" content="My Report">/);
+  assert.match(out, /<meta property="og:description" content="A summary">/);
+  assert.match(out, /<meta property="og:url" content="https:\/\/x\.pages\.dev\/p\/abc\/">/);
+  assert.match(out, /<meta property="og:image" content="https:\/\/img\/og\.png">/);
+  assert.match(out, /<meta property="og:site_name" content="Pagecast">/);
+  assert.match(out, /<meta name="twitter:card" content="summary_large_image">/);
+  assert.ok(out.indexOf("og:title") < out.indexOf("</head>"), "tags go before </head>");
+});
+
+test("injectSocialMeta omits image/site_name when not provided (white-label)", () => {
+  const out = injectSocialMeta("<head></head><body></body>", { title: "T", url: "https://u/" });
+  assert.match(out, /og:title/);
+  assert.doesNotMatch(out, /og:image/);
+  assert.doesNotMatch(out, /og:site_name/);
+});
+
+test("injectSocialMeta leaves a doc that already has its own og: meta untouched", () => {
+  const html = '<head><meta property="og:title" content="Author"></head>';
+  assert.equal(injectSocialMeta(html, { title: "Ours", url: "https://x/" }), html);
+});
+
+test("injectSocialMeta is a no-op when there is no usable content", () => {
+  const html = "<head></head>";
+  assert.equal(injectSocialMeta(html, {}), html);
+});
+
+test("injectSocialMeta escapes attribute-breaking characters", () => {
+  const out = injectSocialMeta("<head></head>", { title: 'A "quote" & <tag>' });
+  assert.match(out, /content="A &quot;quote&quot; &amp; &lt;tag&gt;"/);
+  assert.doesNotMatch(out, /content="A "quote/);
+});
+
+test("injectSocialMeta falls back to before <body> then prepend when no </head>", () => {
+  assert.match(injectSocialMeta("<body><h1>x</h1></body>", { title: "T" }), /og:title[\s\S]*<body>/);
+  assert.match(injectSocialMeta("<h1>frag</h1>", { title: "T" }), /^[\s\S]*og:title[\s\S]*<h1>frag/);
+});
+
+// --- unit: extractors -------------------------------------------------------
+
+test("extractTitle prefers a meaningful <title>, else the fallback, and decodes entities", () => {
+  assert.equal(extractTitle("<title>Q3 Revenue</title>", "fallback"), "Q3 Revenue");
+  assert.equal(extractTitle("<title>index</title>", "Q3 Revenue Dashboard"), "Q3 Revenue Dashboard");
+  assert.equal(extractTitle("<h1>no title</h1>", "Fallback Name"), "Fallback Name");
+  assert.equal(extractTitle("<title>Tom &amp; Jerry</title>", "x"), "Tom & Jerry");
+});
+
+test("extractDescription prefers meta description, else first paragraph text", () => {
+  assert.equal(extractDescription('<meta name="description" content="Meta desc">'), "Meta desc");
+  assert.equal(extractDescription("<p>First <b>para</b> text.</p><p>second</p>"), "First para text.");
+  assert.equal(extractDescription("<div>no para here</div>"), "");
+});
+
+// --- integration: publish stages the OG block ------------------------------
+
+function fakeDeploySpawn(command, args, options) {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => child.emit("exit", null, "SIGTERM");
+  setImmediate(() => {
+    child.stdout.emit("data", Buffer.from("https://abcdef123456.pagecast.pages.dev/"));
+    child.emit("exit", 0, null);
+  });
+  return child;
+}
+
+async function publishOnce({ badge }) {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pagecast-og-"));
+  const dataDir = path.join(tempDir, "data");
+  const reportDir = path.join(tempDir, "report");
+  await fs.mkdir(reportDir, { recursive: true });
+  await fs.writeFile(
+    path.join(reportDir, "index.html"),
+    '<!doctype html><html><head><title>Quarterly Update</title>' +
+      '<meta name="description" content="Revenue up 18%."></head><body><h1>Q</h1></body></html>'
+  );
+
+  const configStore = createConfigStore({ dataDir });
+  await configStore.init();
+  const store = createReportStore({ dataDir });
+  await store.init();
+  const publisher = createCloudflarePagesPublisher({
+    dataDir,
+    spawnImpl: fakeDeploySpawn,
+    timeoutMs: 5000,
+    getBadge: () => badge,
+    getProtectedPublications: () => store.protectedPublicationManifest(),
+    getAuthCookieSecret: () => configStore.get().authCookieSecret
+  });
+
+  const report = await store.addPath(path.join(reportDir, "index.html"));
+  const draft = store.draftPublication(report.id, { kind: "snapshot" });
+  draft.publication.publicUrl = await publisher.publish({
+    report: draft.report,
+    publication: draft.publication,
+    pagesConfig: configStore.get().pages
+  });
+  await store.commitPublication(report.id, draft.publication);
+
+  const slug = draft.publication.slug || draft.publication.token;
+  const staged = await fs.readFile(path.join(publisher.siteRoot, "p", slug, "index.html"), "utf8");
+  return { staged, slug, baseUrl: configStore.get().pages.baseUrl };
+}
+
+test("publishing injects per-report OG meta (badge on → Pagecast card image)", async () => {
+  const { staged, slug, baseUrl } = await publishOnce({ badge: true });
+  assert.match(staged, /<meta property="og:title" content="Quarterly Update">/);
+  assert.match(staged, /<meta property="og:description" content="Revenue up 18%\.">/);
+  assert.ok(staged.includes(`<meta property="og:url" content="${baseUrl}/p/${slug}/">`));
+  assert.ok(staged.includes(`<meta property="og:image" content="${DEFAULT_OG_IMAGE}">`));
+  assert.match(staged, /<meta property="og:site_name" content="Pagecast">/);
+});
+
+test("white-label publish keeps OG text but omits the Pagecast image", async () => {
+  const { staged } = await publishOnce({ badge: false });
+  assert.match(staged, /og:title/);
+  assert.doesNotMatch(staged, /og:image/);
+  assert.doesNotMatch(staged, /og:site_name/);
+});


### PR DESCRIPTION
## What & why

From the growth-loop brainstorm: the **"Published with Pagecast" badge only fires *after* a click.** The biggest untapped reach lever is the surface *before* the click — how a published report unfurls when its link lands in Slack / X / iMessage / LinkedIn. Agent-generated reports ship with **no Open Graph tags**, so they unfurl as bare, ugly URLs.

This auto-injects per-report OG/Twitter meta at publish so every shared link unfurls richly — and (for non-white-label users) carries a Pagecast-branded card into every feed, the pre-click complement to the badge.

## What it does

At publish, `injectSocialMeta` adds into the report's `<head>`:
- `og:title` (the `<title>` if meaningful, else the report name), `og:description` (meta description → first paragraph → omitted), `og:url`, `og:type=article`
- `twitter:card=summary_large_image` + mirrored `twitter:title/description/image`
- **Branding only when the badge is on:** `og:image` (a Pagecast card already hosted at `pagecasthq.pages.dev/og-image.png`) + `og:site_name=Pagecast`. **White-label** pages (badge off) get clean per-report unfurls with **no** Pagecast branding.

**Safeguards:** idempotent — if the author already declared `og:` meta, the doc is left untouched; all attribute values escaped; entities decoded first so they aren't double-escaped.

## Notes

- No new dependencies and no new bundled assets — the OG image reuses the already-hosted landing card (`DEFAULT_OG_IMAGE`, a one-line constant to change later).
- Protected pages won't unfurl (the edge gate 401s scrapers) — expected; a branded "🔒 protected" gate card is a possible follow-up.

## Verification

- `npm run check && npm test` → **103 pass / 0 fail** (10 new: `injectSocialMeta` tags/gating/idempotency/escaping, `extractTitle`/`extractDescription`, and a publish→staged-HTML integration test incl. the white-label path).
- **Live on Cloudflare:** published a report and confirmed the deployed `/p/<slug>/` page carries the full `og:`/`twitter:` block, with `og:url` resolved to the live link and the badge-gated image present.

## v2 (deferred)

Per-report **dynamic** card images (the report title rendered into the card) via a Cloudflare Worker (Satori/resvg-wasm) — higher fidelity, more infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amal-david/pagecast/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published pages now generate optimized metadata for social media sharing, enabling rich preview cards when shared on social platforms.
  * White-labeled pages display clean unfurls without platform-specific branding elements.
  * Metadata automatically includes page title, description, and images extracted from your content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->