### PR TITLE
CI: add SHA-pinned npm release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+# Publish pagecast to npm.
+#
+# Trigger: publishes the version currently in package.json when you cut a GitHub
+# Release (or run the workflow manually). npm publishes whatever version is in
+# package.json — bump it and commit BEFORE creating the release/tag.
+#
+# Requires one repo secret: NPM_TOKEN (an npm automation/granular token with
+# publish rights to `pagecast`). Add it under Settings → Secrets and variables →
+# Actions. The token is the only credential; `npm publish` reads it via
+# NODE_AUTH_TOKEN.
+#
+# Supply-chain hardening:
+#   - every action is pinned to a full commit SHA (not a moveable tag)
+#   - the web UI install is frozen-lockfile + --ignore-scripts (via `npm run build`)
+#   - publish uses --provenance (signed build attestation; needs id-token: write)
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # required for npm --provenance
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up pnpm # used by `npm run build` to build the web UI
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        with:
+          version: 10
+
+      - name: Set up Node
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      # `npm publish` runs the package's prepack/prepublishOnly hooks, which build
+      # the web UI (pnpm, frozen lockfile) and run `npm run check` + `npm test`.
+      # A failing build/check/test blocks the publish.
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What

Adds `.github/workflows/release.yml` — the automated npm publish you asked about (there was no `.github/workflows/` before; publishing was fully manual).

**Trigger:** publishes when you cut a **GitHub Release** (or via manual **workflow_dispatch**). npm publishes whatever version is in `package.json`, so the flow is: bump `package.json` → commit → create a Release with the matching tag → it publishes.

## Supply-chain hardening (per our rules)

- Every action **pinned to a full commit SHA**, not a moveable tag:
  - `actions/checkout` `11bd719…` (v4.2.2)
  - `pnpm/action-setup` `a7487c7…` (v4.1.0)
  - `actions/setup-node` `39370e3…` (v4.1.0)
- Web UI install is **frozen-lockfile + `--ignore-scripts`** (runs through the package's existing `prepack` → `npm run build`).
- `npm publish --provenance` (signed build attestation; needs `id-token: write`, already scoped in the workflow).
- No `pull_request_target`, no secret serialization — only `NPM_TOKEN` is read, via `NODE_AUTH_TOKEN`.

`npm publish` runs `prepack`/`prepublishOnly`, so a failing **build / check / test gates the publish**.

## To activate (two one-time steps)

1. **Merge this PR** — `release`/`workflow_dispatch` triggers run the workflow from `main`.
2. **Add the `NPM_TOKEN` repo secret** (Settings → Secrets and variables → Actions) — an npm **automation / granular** token with publish rights to `pagecast`. *(Adding a secret is an account action — that's yours; I don't handle tokens.)*

Then: bump `package.json` (e.g. `npm version minor` → `0.2.0`), push, and publish a GitHub Release → it ships to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amal-david/pagecast/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->