### PR TITLE
feat: Docker support (Dockerfile, compose, headless CLI)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,46 @@
+# Keep the build context small and free of local state / secrets.
+# Note: only files COPY'd in the Dockerfile end up in the image anyway; this just
+# speeds up the build and avoids shipping anything sensitive into the context.
+
+.git
+.gitignore
+node_modules
+**/node_modules
+
+# Local pagecast state and Cloudflare/wrangler caches.
+.pagecast
+.wrangler
+
+# Secrets — never into the build context. (.env.example is fine, but unused here.)
+.env
+.env.*
+!.env.example
+
+# The React admin source + heavy assets (the built UI already lives in public/).
+web
+media
+launch
+extension
+plugin
+docs
+test
+*.zip
+*.log
+
+# Agent / tooling config directories.
+.github
+.superplan
+.codex
+.agents
+.amazonq
+.claude
+.claude-plugin
+.cursor
+.gemini
+.opencode
+
+# Docs / Docker meta (not needed at runtime).
+*.md
+Dockerfile
+docker-compose.yml
+.dockerignore

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Optional: enable publishing to Cloudflare Pages from inside the Docker container.
+#
+# The dashboard's "Connect Cloudflare" button uses a browser OAuth flow that a
+# container can't complete, so authenticate with an API token instead.
+#
+# Create a token at https://dash.cloudflare.com/profile/api-tokens with:
+#   - Account > Cloudflare Pages > Edit
+#   - Account > Account Settings > Read
+#
+# Then:  cp .env.example .env  and fill these in. docker-compose reads this file.
+CLOUDFLARE_API_TOKEN=
+CLOUDFLARE_ACCOUNT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # Runtime data + build deps
 .pagecast/
 .wrangler/
+
+# Local secrets for Docker (the template .env.example stays tracked)
+.env
+.env.*
+!.env.example
 pagecast-extension.zip
 node_modules/
 web/node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1
+
+# pagecast — preview & publish HTML reports.
+#
+# This image bundles the full `pagecast` CLI, so a single image both serves the
+# admin dashboard (`serve`, the default command) AND runs every publish/deploy
+# subcommand. The dashboard and the CLI are the same program — installing one
+# installs both.
+#
+# Base is Node 22 (current LTS): pagecast needs >=20, and a pinned wrangler needs
+# >=22, so 22 satisfies both.
+FROM node:22-slim
+
+# wrangler is the Cloudflare CLI that pagecast shells out to for publishing and
+# deploys. Bake a pinned version into the image so deploys are reproducible and
+# don't fetch wrangler over the network on first use. Pin exactly (no `latest`,
+# no `^`) per supply-chain hygiene; bump deliberately. `npx wrangler` inside the
+# app resolves this globally-installed binary instead of downloading one.
+ARG WRANGLER_VERSION=4.101.0
+RUN npm install --global --no-audit --no-fund "wrangler@${WRANGLER_VERSION}" \
+  && npm cache clean --force
+
+WORKDIR /app
+
+# pagecast has zero runtime npm dependencies, so there is nothing to `npm install`
+# for the app itself — copy only the files the CLI needs at runtime.
+COPY package.json llms.txt ./
+COPY src/ ./src/
+COPY public/ ./public/
+COPY feedback/ ./feedback/
+
+# Inside a container the servers must listen on all interfaces for Docker port
+# mapping to reach them; outside Docker the default stays 127.0.0.1. ALWAYS map
+# these ports to the host's loopback only (see docker-compose.yml) — the admin
+# API is unauthenticated and can run shell commands.
+ENV HOST=0.0.0.0 \
+    PORT=4173 \
+    PUBLIC_PORT=4174
+
+EXPOSE 4173 4174
+
+# Liveness probe for the `serve` workflow: the admin server answers loopback
+# requests (Host: localhost passes its DNS-rebinding guard). Uses node directly
+# so the slim image needs no curl/wget.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "require('http').get('http://127.0.0.1:'+(process.env.PORT||4173)+'/',r=>process.exit(r.statusCode<500?0:1)).on('error',()=>process.exit(1))"
+
+# Absolute path so the CLI works even when callers override the working dir,
+# e.g. `docker run -v "$PWD:/work" -w /work pagecast publish ./report.html`.
+ENTRYPOINT ["node", "/app/src/cli.js"]
+CMD ["serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,17 @@ RUN npm install --global --no-audit --no-fund "wrangler@${WRANGLER_VERSION}" \
 WORKDIR /app
 
 # pagecast has zero runtime npm dependencies, so there is nothing to `npm install`
-# for the app itself — copy only the files the CLI needs at runtime.
-COPY package.json llms.txt ./
-COPY src/ ./src/
-COPY public/ ./public/
-COPY feedback/ ./feedback/
+# for the app itself — copy only the files the CLI needs at runtime. Own them as
+# the unprivileged `node` user (uid 1000, shipped with the base image).
+COPY --chown=node:node package.json llms.txt ./
+COPY --chown=node:node src/ ./src/
+COPY --chown=node:node public/ ./public/
+COPY --chown=node:node feedback/ ./feedback/
+
+# Pre-create the state dir and hand /app to `node` so the unprivileged process
+# can write .pagecast when no volume is mounted (and with a named volume, which
+# inherits this ownership). A bind mount uses the host dir's ownership instead.
+RUN mkdir -p /app/.pagecast && chown -R node:node /app
 
 # Inside a container the servers must listen on all interfaces for Docker port
 # mapping to reach them; outside Docker the default stays 127.0.0.1. ALWAYS map
@@ -44,6 +50,11 @@ EXPOSE 4173 4174
 # so the slim image needs no curl/wget.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD node -e "require('http').get('http://127.0.0.1:'+(process.env.PORT||4173)+'/',r=>process.exit(r.statusCode<500?0:1)).on('error',()=>process.exit(1))"
+
+# Drop root: the admin API is unauthenticated and can run shell commands, so the
+# runtime process runs as the unprivileged `node` user. Ports 4173/4174 are
+# >1024, so no privilege is needed to bind them.
+USER node
 
 # Absolute path so the CLI works even when callers override the working dir,
 # e.g. `docker run -v "$PWD:/work" -w /work pagecast publish ./report.html`.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ In the admin UI, click **Connect Cloudflare**. Pagecast uses scoped Wrangler
 OAuth (`account:read`, `user:read`, `pages:write`), detects your account, and
 creates the Pages project if needed. From a clone, run `npm start`.
 
+Prefer containers? Pagecast ships with Docker support — see [Run with Docker](#run-with-docker).
+
 Prefer the terminal?
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -158,7 +158,13 @@ Notes:
 
 - The admin API is unauthenticated and can run shell commands, so the container
   binds `0.0.0.0` internally but the compose file maps the ports to the host's
-  **loopback only** (`127.0.0.1`). Don't expose them on a routable interface.
+  **loopback only** (`127.0.0.1`). If you start `serve` with `docker run` instead
+  of compose, publish to loopback too — `-p 127.0.0.1:4173:4173`, never a bare
+  `-p 4173:4173`. Set `HOST` only to `127.0.0.1` or `0.0.0.0`, never a routable IP.
+- On Linux the container runs as uid 1000 (`node`); if a bind-mounted `./.pagecast`
+  isn't writable by that uid you'll get permission errors. `mkdir -p .pagecast`
+  before `compose up` (or `chown 1000:1000 .pagecast`) fixes it. Docker Desktop and
+  OrbStack handle this automatically.
 - `wrangler` is pinned and baked into the image, so deploys don't fetch it at
   runtime. Bump `WRANGLER_VERSION` in the `Dockerfile` to update it.
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,46 @@ cp plugin/skills/publish-report/SKILL.md /path/to/your-agent/skills/publish-repo
 
 More detail in [plugin/README.md](plugin/README.md).
 
+## Run with Docker
+
+A single image bundles the whole `pagecast` CLI, so it serves the admin dashboard
+**and** runs every publish/deploy command — they are the same program.
+
+```sh
+# Serve the dashboard (build on first run, then open http://localhost:4173)
+docker compose up --build
+```
+
+The local published-page preview is on `http://localhost:4174`, and your config +
+publish history persist in `./.pagecast` (mounted as a volume).
+
+**Publishing from a container uses an API token, not the dashboard's "Connect
+Cloudflare" button** — that button opens a browser OAuth flow a container can't
+complete. Copy `.env.example` to `.env`, add a scoped token, and `docker compose`
+picks it up:
+
+```sh
+cp .env.example .env   # fill in CLOUDFLARE_API_TOKEN (+ CLOUDFLARE_ACCOUNT_ID)
+```
+
+Run any command headlessly (CI, servers) from the same image — mount your working
+directory and pass the token through:
+
+```sh
+docker build -t pagecast .
+docker run --rm -v "$PWD:/work" -w /work \
+  -e CLOUDFLARE_API_TOKEN -e CLOUDFLARE_ACCOUNT_ID \
+  pagecast publish ./report.html --json
+```
+
+Notes:
+
+- The admin API is unauthenticated and can run shell commands, so the container
+  binds `0.0.0.0` internally but the compose file maps the ports to the host's
+  **loopback only** (`127.0.0.1`). Don't expose them on a routable interface.
+- `wrangler` is pinned and baked into the image, so deploys don't fetch it at
+  runtime. Bump `WRANGLER_VERSION` in the `Dockerfile` to update it.
+
 ## Chrome Extension (Experimental)
 
 > ⚠️ Experimental — load-unpacked only, not yet on the Chrome Web Store.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+# Run the pagecast admin dashboard + local page server in a container.
+#
+#   docker compose up --build      # then open http://localhost:4173
+#
+# Publishing to Cloudflare from inside the container uses an API token: the
+# dashboard's interactive "Connect Cloudflare" OAuth flow needs a browser the
+# container does not have. Copy .env.example to .env and fill in the token to
+# enable publishing / deploys.
+services:
+  pagecast:
+    build: .
+    image: pagecast:local
+    # Persist config + published history across container restarts.
+    volumes:
+      - ./.pagecast:/app/.pagecast
+    # Map ONLY to the host loopback: the admin API is unauthenticated and can run
+    # shell commands, so it must never be published on a routable interface.
+    ports:
+      - "127.0.0.1:4173:4173"  # admin dashboard
+      - "127.0.0.1:4174:4174"  # local published-page server
+    environment:
+      HOST: "0.0.0.0"
+      # Optional — enables Cloudflare publishing from the container (see .env).
+      CLOUDFLARE_API_TOKEN: "${CLOUDFLARE_API_TOKEN:-}"
+      CLOUDFLARE_ACCOUNT_ID: "${CLOUDFLARE_ACCOUNT_ID:-}"
+    # `serve` is the image default; stated here for clarity.
+    command: ["serve"]

--- a/src/server.js
+++ b/src/server.js
@@ -4979,10 +4979,16 @@ export async function startServers({
     watchManager.register(report.id);
   }
 
+  // `host` may be a wildcard bind address (0.0.0.0 / ::) — correct for listen(),
+  // but invalid as a hostname in client-facing URLs (browsers, incl. Chrome
+  // 128+, refuse to connect to 0.0.0.0). Hand back a loopback display host for
+  // the URLs that reach the admin UI and the terminal.
+  const urlHost = host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
+
   const publicServer = createServer(createPublicHandler({ store }));
   await listen(publicServer, { host, port: publicPort });
   const actualPublicPort = publicServer.address().port;
-  const localPublicBaseUrl = `http://${host}:${actualPublicPort}`;
+  const localPublicBaseUrl = `http://${urlHost}:${actualPublicPort}`;
   let adminBaseUrl = null;
   const tunnelManager = new TunnelManager({
     localUrl: localPublicBaseUrl,
@@ -5014,7 +5020,7 @@ export async function startServers({
   }
 
   const actualAdminPort = adminServer.address().port;
-  const adminUrl = `http://${host}:${actualAdminPort}`;
+  const adminUrl = `http://${urlHost}:${actualAdminPort}`;
   adminBaseUrl = adminUrl;
 
   return {

--- a/src/server.js
+++ b/src/server.js
@@ -4981,14 +4981,19 @@ export async function startServers({
 
   // `host` may be a wildcard bind address (0.0.0.0 / ::) — correct for listen(),
   // but invalid as a hostname in client-facing URLs (browsers, incl. Chrome
-  // 128+, refuse to connect to 0.0.0.0). Hand back a loopback display host for
-  // the URLs that reach the admin UI and the terminal.
+  // 128+, refuse to connect to 0.0.0.0). Map wildcard binds to a loopback host
+  // for the URLs we hand back to the admin UI and terminal, and for the admin
+  // host-header allowlist (so a wildcard bind doesn't make `Host: 0.0.0.0`
+  // trusted). `urlHost` stays unbracketed for the allowlist comparison;
+  // `hostForUrl` brackets IPv6 literals (e.g. ::1) so URLs stay well-formed:
+  // http://[::1]:4173, not http://::1:4173.
   const urlHost = host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
+  const hostForUrl = urlHost.includes(":") ? `[${urlHost}]` : urlHost;
 
   const publicServer = createServer(createPublicHandler({ store }));
   await listen(publicServer, { host, port: publicPort });
   const actualPublicPort = publicServer.address().port;
-  const localPublicBaseUrl = `http://${urlHost}:${actualPublicPort}`;
+  const localPublicBaseUrl = `http://${hostForUrl}:${actualPublicPort}`;
   let adminBaseUrl = null;
   const tunnelManager = new TunnelManager({
     localUrl: localPublicBaseUrl,
@@ -5008,7 +5013,7 @@ export async function startServers({
       tunnelManager,
       deployQueue,
       watchManager,
-      bindHost: host
+      bindHost: urlHost
     })
   );
 
@@ -5020,7 +5025,7 @@ export async function startServers({
   }
 
   const actualAdminPort = adminServer.address().port;
-  const adminUrl = `http://${urlHost}:${actualAdminPort}`;
+  const adminUrl = `http://${hostForUrl}:${actualAdminPort}`;
   adminBaseUrl = adminUrl;
 
   return {

--- a/src/server.js
+++ b/src/server.js
@@ -4931,7 +4931,7 @@ function closeServer(server) {
 }
 
 export async function startServers({
-  host = DEFAULT_HOST,
+  host = process.env.HOST || DEFAULT_HOST,
   adminPort = Number(process.env.PORT || DEFAULT_ADMIN_PORT),
   publicPort = Number(process.env.PUBLIC_PORT || DEFAULT_PUBLIC_PORT),
   dataDir = path.join(PROJECT_ROOT, ".pagecast"),

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2775,6 +2775,46 @@ test("admin server rejects requests with a non-loopback Host header (DNS rebindi
   }
 });
 
+test("a wildcard bind host (0.0.0.0, e.g. in Docker) yields loopback URLs and does not trust Host: 0.0.0.0", async () => {
+  const { request } = await import("node:http");
+  const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "pagecast-wildcard-"));
+  const runtime = await startServers({
+    host: "0.0.0.0",
+    adminPort: 0,
+    publicPort: 0,
+    dataDir,
+    staticDir: path.resolve("public")
+  });
+
+  const callWithHost = (hostHeader) =>
+    new Promise((resolve, reject) => {
+      const port = runtime.adminServer.address().port;
+      const req = request(
+        { host: "127.0.0.1", port, path: "/api/status", method: "GET", headers: { Host: hostHeader } },
+        (res) => {
+          res.resume();
+          resolve(res.statusCode);
+        }
+      );
+      req.on("error", reject);
+      req.end();
+    });
+
+  try {
+    // Client-facing URLs must use a loopback host, never the wildcard bind
+    // address (browsers, incl. Chrome 128+, refuse to connect to 0.0.0.0).
+    assert.match(runtime.adminUrl, /^http:\/\/127\.0\.0\.1:\d+$/);
+    assert.match(runtime.publicUrl, /^http:\/\/127\.0\.0\.1:\d+$/);
+    // The wildcard bind must NOT make `Host: 0.0.0.0` a trusted loopback host.
+    assert.equal(await callWithHost("0.0.0.0"), 403);
+    // Real loopback Hosts still pass.
+    assert.notEqual(await callWithHost("127.0.0.1"), 403);
+  } finally {
+    await runtime.close();
+    await fs.rm(dataDir, { recursive: true, force: true });
+  }
+});
+
 test("injectFeedbackWidget adds the widget script before </body> exactly once", () => {
   const html = "<!doctype html><html><head></head><body><h1>Report</h1></body></html>";
   const out = injectFeedbackWidget(html, { url: "https://fb.example.workers.dev", slug: "q3" });


### PR DESCRIPTION
## What

Adds Docker support to pagecast. **One image bundles the full `pagecast` CLI**, so it both serves the admin dashboard (`serve`, the default) and runs every publish/deploy subcommand — they're the same program, so one install gives you both.

| File | Purpose |
|---|---|
| `Dockerfile` | `node:22-slim` + pinned, baked-in `wrangler@4.101.0`; defaults to `serve`, runs any subcommand |
| `docker-compose.yml` | The `serve` workflow — loopback-only port mapping + `.pagecast` volume |
| `.env.example` | API-token auth for publishing from a container |
| `.dockerignore` | Lean, secret-free build context |
| `src/server.js` | `startServers` honours `HOST` env (1-line change) |
| `README.md` | New **Run with Docker** section |

## Key design decisions

- **One image, not two.** The dashboard and the CLI are the same package; splitting them would add no value. Image defaults to `serve` but runs any subcommand (`docker run … pagecast publish ./report.html`).
- **Publishing uses an API token, not the dashboard's "Connect Cloudflare" button.** That button opens a browser OAuth flow a container can't complete, so headless auth is `CLOUDFLARE_API_TOKEN` (+ `CLOUDFLARE_ACCOUNT_ID`). This is the single most important caveat — documented in the README and `.env.example`.
- **Loopback security model preserved.** The admin API is unauthenticated and can run shell commands, so it's `127.0.0.1`-only by design. The container binds `0.0.0.0` internally (required for port mapping), but `HOST` defaults to `127.0.0.1` *outside* Docker, and compose maps ports to the **host's loopback only**. The DNS-rebinding guard still rejects non-loopback `Host` headers (verified below).
- **`node:22-slim`, not 20 or alpine.** wrangler needs Node ≥22; pagecast needs ≥20 — 22 satisfies both. Debian slim avoids the musl/`workerd` footgun alpine has.
- **wrangler pinned + baked in.** Reproducible, offline deploys; `4.101.0` is >7 days old (supply-chain cooldown). Bump via `WRANGLER_VERSION`.

## Verification (all passing)

- `npm run check` + `npm test` → **123/123 pass**
- `docker build` → OK; wrangler runs on Node 22.23.1
- `serve`: admin `200`, public server live (`404` with no pages), **rebinding guard still `403`s `Host: evil.example`**
- `HEALTHCHECK` reaches `healthy`
- Headless entrypoint works under overridden `-w /work` (absolute entrypoint path)

## Open knob for review

wrangler is **baked into the image** (~+35 packages, reproducible/offline) vs. letting pagecast fetch it via `npx` at runtime (smaller image, needs network + unpinned). I went with baking it in; easy to flip if you'd rather keep the image slim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amal-david/pagecast/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Dockerfile and Docker Compose setup, including container health checks for the admin dashboard and local preview.
* **Bug Fixes**
  * Improved wildcard `HOST` handling so user-facing URLs use loopback, while host-header trust remains secure when binding to `0.0.0.0`/`::`.
* **Tests**
  * Added a regression test for wildcard-host URL generation and Host header trust behavior.
* **Documentation**
  * Updated the README with “Run with Docker” instructions and required Cloudflare environment variables.
* **Chores**
  * Added `.dockerignore`, updated `.gitignore`, and populated `.env.example` for container publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->