### PR TITLE
Memorable publish slugs: existential all-words names (no random tail)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "start": "node src/cli.js",
     "build": "pnpm -C web install --frozen-lockfile --ignore-scripts && pnpm -C web run build",
-    "check": "node --check src/server.js && node --check src/cli.js && node --check src/markdown.js",
+    "check": "node --check src/server.js && node --check src/cli.js && node --check src/markdown.js && node --check src/nameGenerator.js",
     "test": "node --test",
     "prepack": "npm run build && npm run check && npm test",
     "prepublishOnly": "npm run check && npm test"

--- a/src/nameGenerator.js
+++ b/src/nameGenerator.js
@@ -229,6 +229,9 @@ const TEMPLATES = [
 // Generate one memorable name. Pass { template } to force a specific shape (0-4)
 // and { rng } (e.g. makeRng(seed)) for deterministic output in tests.
 export function generateName({ rng = cryptoRng, template } = {}) {
+  if (template !== undefined && typeof TEMPLATES[template] !== "function") {
+    throw new RangeError(`Invalid name template index: ${template}`);
+  }
   for (let attempt = 0; attempt < 20; attempt += 1) {
     const build = template === undefined ? pick(TEMPLATES, rng) : TEMPLATES[template];
     const name = build(rng).join("-");
@@ -252,9 +255,14 @@ export function generateUniqueName(isTaken = () => false, { rng = cryptoRng, gen
     if (!isTaken(name)) return name;
   }
   let name = gen();
-  for (let guard = 0; guard < 100 && isTaken(name); guard += 1) {
+  for (let guard = 0; guard < 100; guard += 1) {
+    if (!isTaken(name)) return name;
     const candidate = `${name}-${pick(NOUNS, rng)}`;
     name = candidate.length <= MAX_LENGTH ? candidate : gen();
   }
-  return name;
+  if (!isTaken(name)) return name;
+  // Never hand back a colliding slug — that would break the token-identity
+  // contract (findPublication / revoke / sync). Exhausting the (huge) namespace
+  // is a real, surfaceable error rather than a silent duplicate.
+  throw new Error("generateUniqueName: unable to find a unique name after retries");
 }

--- a/src/nameGenerator.js
+++ b/src/nameGenerator.js
@@ -1,0 +1,260 @@
+// Generates quirky, memorable, all-words names for published report URLs — e.g.
+// "hollow-paperclip", "dreamily-fading-casket", "nostalgic-curie" — in the
+// spirit of the random names ngrok / localtunnel / Heroku / Docker assign, but
+// with a much larger, multi-theme library and NO trailing random digits.
+//
+// Zero runtime dependencies on purpose: the root CLI/server forbids npm deps, so
+// the word lists are vendored here as plain arrays. They are an ORIGINAL curated
+// pack written for Pagecast, spanning existential/mood, whimsical, color,
+// texture, size, weather, cosmic, and "famous scientist" themes.
+//
+// IMPORTANT: these names carry NO entropy tail, so a slug is guessable and is NOT
+// an access-control boundary. Uniqueness comes from the large library plus a
+// per-publish collision check (see generateUniqueName); secrecy must come from
+// password protection, not the URL.
+//
+// Every emitted name is a valid DNS label — matches
+// /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/ and stays well under 63 chars — so it
+// can also serve as a clean public slug.
+
+import { randomInt } from "node:crypto";
+
+// Drop anything that is not a clean lowercase word and de-duplicate, so the
+// generator is robust even if a list is later edited carelessly.
+function clean(words) {
+  return [...new Set(words.filter((w) => /^[a-z]{2,20}$/.test(w)))];
+}
+
+export const ADVERBS = clean([
+  "quietly", "dreamily", "absurdly", "faintly", "eternally", "briskly", "wearily", "gleefully", "softly", "boldly",
+  "calmly", "sweetly", "wildly", "gently", "gladly", "grimly", "hastily", "keenly", "lazily", "madly",
+  "meekly", "nimbly", "oddly", "primly", "proudly", "rudely", "sadly", "shyly", "slyly", "tartly",
+  "vainly", "warmly", "wryly", "aptly", "coyly", "drily", "gaily", "tamely", "duly", "newly",
+  "merrily", "cheerily", "drearily", "wistfully", "mournfully", "joyfully", "sleepily", "wakefully", "restlessly", "endlessly",
+  "hopelessly", "helplessly", "fearlessly", "carelessly", "recklessly", "ruthlessly", "gracefully", "gratefully", "tactfully", "artfully",
+  "blissfully", "wishfully", "mindfully", "gainfully", "painfully", "mercifully", "wonderfully", "faithfully", "skillfully", "willfully",
+  "bashfully", "boastfully", "dolefully", "fancifully", "forcefully", "fretfully", "fitfully", "sorrowfully", "tearfully", "thoughtfully",
+  "truthfully", "watchfully", "cunningly", "glowingly", "longingly", "lovingly", "mockingly", "soothingly", "sparingly", "strikingly",
+  "tellingly", "willingly", "yearningly", "achingly", "amusingly", "charmingly", "daringly", "dashingly", "dazzlingly", "fetchingly",
+  "haltingly", "laughingly", "shockingly", "sickeningly", "startlingly", "swimmingly", "teasingly", "weepingly", "wittingly", "beautifully",
+  "blindly", "bravely", "briefly", "brightly", "clumsily", "coldly", "crisply", "crookedly", "curiously", "dearly",
+  "deeply", "dimly", "drowsily", "eagerly", "earnestly", "easily", "fondly", "frankly", "freely", "frostily",
+  "gruffly", "handsomely", "happily", "harshly", "heavily", "hugely", "humbly", "icily", "idly", "jaggedly",
+  "jauntily", "jokingly", "jumpily", "kindly", "knowingly", "loudly", "luckily", "mistily", "mutely", "nervously",
+  "nicely", "nobly", "numbly", "openly", "palely", "plainly", "quaintly", "queerly", "rapidly", "richly",
+  "ripely", "roundly", "rosily", "royally", "rustily", "sagely", "saltily", "scarcely", "secretly", "serenely",
+  "sharply", "silently", "simply", "sincerely", "singly", "sleekly", "slowly", "smartly", "smoothly", "snugly",
+  "solemnly", "somberly", "sparkly", "speedily", "stiffly", "stoutly", "sternly", "stormily", "strangely", "sturdily",
+  "suddenly", "sunnily", "surely", "swiftly", "tenderly", "tersely", "tidily", "tightly", "timidly", "tiredly",
+  "tonelessly", "triumphantly", "trustingly", "unevenly", "urgently", "vaguely", "valiantly", "vastly", "vividly", "wanly",
+  "wickedly", "wisely", "witlessly", "wobbly", "wondrously", "woozily", "wordlessly", "worriedly", "zanily", "zestfully"
+]);
+
+export const ADJECTIVES = clean([
+  "hollow", "doomed", "fleeting", "wistful", "vacant", "restless", "weary", "yearning", "forlorn", "somber",
+  "wishful", "dreary", "mournful", "ghostly", "faded", "frayed", "wilted", "muted", "numbed", "drowsy",
+  "wakeful", "ageless", "timeless", "fated", "brooding", "pensive", "lonesome", "listless", "haunted", "hushed",
+  "wandering", "wayward", "aimless", "blissful", "bouncy", "fuzzy", "jolly", "peculiar", "nifty", "quirky",
+  "wacky", "zany", "goofy", "perky", "spunky", "plucky", "cheeky", "sprightly", "whimsical", "giddy",
+  "merry", "jovial", "chipper", "frisky", "spry", "kooky", "loopy", "wobbly", "bumbling", "fumbling",
+  "snappy", "zippy", "peppy", "chirpy", "sassy", "cheery", "gleeful", "jaunty", "crimson", "amber",
+  "indigo", "slate", "ivory", "scarlet", "auburn", "azure", "cobalt", "copper", "emerald", "golden",
+  "russet", "saffron", "sienna", "teal", "violet", "amethyst", "beige", "bronze", "cerulean", "charcoal",
+  "coral", "crimsoned", "ebony", "fawn", "flaxen", "jade", "lavender", "lilac", "magenta", "maroon",
+  "ochre", "olive", "peach", "pewter", "rosy", "ruby", "sapphire", "silvery", "tawny", "topaz",
+  "turquoise", "velvety", "verdant", "vermilion", "viridian", "velvet", "brittle", "glassy", "woolen", "marble",
+  "satin", "silken", "leathery", "papery", "feathery", "downy", "fluffy", "fuzzed", "grainy", "gritty",
+  "powdery", "rubbery", "rugged", "chalky", "crusty", "crumbly", "flaky", "frothy", "glossy", "gnarled",
+  "knotty", "lacquered", "mossy", "oaken", "pebbly", "plush", "porous", "prickly", "ragged", "silty",
+  "sinewy", "slimy", "spongy", "steely", "stony", "tinny", "waxen", "wiry", "woody", "crystalline",
+  "tiny", "vast", "crooked", "round", "jagged", "squat", "towering", "spindly", "stubby", "lanky",
+  "burly", "dainty", "colossal", "minute", "slender", "bulbous", "craggy", "curved", "cylindrical", "domed",
+  "elongated", "flattened", "gaunt", "gigantic", "hulking", "immense", "lopsided", "massive", "narrow", "oblong",
+  "petite", "plump", "pointed", "puny", "scrawny", "sprawling", "squarish", "tapered", "teeny", "titanic",
+  "tubular", "twisted", "wee", "wide", "zigzag", "frosty", "balmy", "stormy", "misty", "sunlit",
+  "wintry", "drizzly", "gusty", "blustery", "breezy", "chilly", "cloudy", "damp", "dewy", "foggy",
+  "frozen", "glacial", "hazy", "humid", "muggy", "overcast", "parched", "rainy", "scorching", "sleety",
+  "snowy", "steamy", "sultry", "sweltering", "thundery", "tropical", "windswept", "wintery", "sunny", "cloudless",
+  "moonlit", "starlit", "tempestuous", "torrid", "arctic", "cosmic", "infinite", "quantum", "astral", "eternal",
+  "boundless", "celestial", "ethereal", "fathomless", "galactic", "heavenly", "interstellar", "limitless", "lunar", "nebulous",
+  "orbital", "planetary", "sidereal", "solar", "stellar", "sublime", "supernal", "transcendent", "unbounded", "abstract",
+  "ephemeral", "immortal", "mythic", "mystic", "numinous", "oracular", "primordial", "spectral", "timeworn", "unearthly",
+  "ancient", "antique", "arcane", "bygone", "fabled", "legendary", "olden", "quaint", "storied", "vintage",
+  "rustic", "weathered", "worn", "wizened", "aged", "crumbling", "derelict", "dilapidated", "forgotten", "mossgrown",
+  "ruined", "tumbledown", "venerable", "cobwebbed", "dusty", "musty", "ramshackle", "airy", "brisk", "buoyant",
+  "calm", "carefree", "cozy", "dapper", "dashing", "dazzling", "delicate", "dewfresh", "dreamy", "dulcet",
+  "elegant", "fancy", "fragrant", "gallant", "genial", "gentle", "glad", "graceful", "grand", "handsome",
+  "honeyed", "jubilant", "keen", "kindly", "lively", "lofty", "lucid", "luminous", "lush", "mellow",
+  "noble", "opulent", "pearly", "placid", "pleasant", "posh", "pristine", "quiet", "radiant", "refined",
+  "regal", "serene", "shimmering", "sleek", "sprightful", "stately", "blithe", "sweet", "tender", "tranquil",
+  "vivid", "wondrous", "zestful", "bashful", "bewildered", "bored", "cranky", "cross", "curious", "dazed",
+  "dizzy", "dopey", "dour", "drained", "droopy", "fretful", "frazzled", "frantic", "gloomy", "grumpy",
+  "jaded", "jittery", "jumpy", "languid", "leaden", "limp", "lethargic", "listful", "moody", "mopey",
+  "morose", "peevish", "perplexed", "pining", "queasy", "sluggish", "somnolent", "sullen", "torpid", "woeful",
+  "woozy", "yawning", "befuddled", "crestfallen", "despondent", "disheveled", "downcast", "dreamful", "fidgety", "flustered",
+  "agile", "brave", "bright", "clever", "crafty", "cunning", "daring", "deft", "eager", "fearless",
+  "fierce", "gallivanting", "heroic", "intrepid", "mighty", "nimble", "plinky", "quick", "rakish", "scrappy",
+  "shrewd", "spirited", "stalwart", "swift", "tenacious", "valiant", "vigorous", "wily", "adventurous", "bold",
+  "dauntless", "doughty", "sturdy", "gutsy", "mettlesome", "resolute", "stouthearted", "undaunted", "venturous", "glinting",
+  "twinkling", "sparkling", "blazing", "burnished", "candlelit", "dappled", "flickering", "gilded", "glimmering", "glistening",
+  "iridescent", "lambent", "molten", "opalescent", "phosphorescent", "prismatic", "resplendent", "scintillating", "shadowy", "smoldering",
+  "sunbright", "translucent", "gleaming", "incandescent"
+]);
+
+export const NOUNS = clean([
+  "toaster", "stapler", "kettle", "umbrella", "spreadsheet", "teapot", "thimble", "corkscrew", "mousepad", "doorknob",
+  "lampshade", "spatula", "whisk", "ladle", "colander", "saucepan", "skillet", "strainer", "sieve", "trivet",
+  "coaster", "napkin", "tablecloth", "placemat", "dustpan", "broom", "mop", "bucket", "sponge", "squeegee",
+  "plunger", "wrench", "hammer", "screwdriver", "pliers", "ratchet", "sandpaper", "chisel", "mallet", "clamp",
+  "scissors", "tweezers", "stencil", "paperclip", "pushpin", "thumbtack", "rubberband", "clipboard", "binder", "folder",
+  "envelope", "postcard", "notebook", "journal", "calendar", "bookmark", "inkwell", "quill", "crayon", "marker",
+  "eraser", "ruler", "compass", "protractor", "abacus", "calculator", "typewriter", "telephone", "doorbell", "mailbox",
+  "birdhouse", "wheelbarrow", "watering", "flowerpot", "hammock", "lantern", "candle", "matchbox", "flashlight", "keychain",
+  "wallet", "satchel", "backpack", "suitcase", "briefcase", "handbag", "lunchbox", "thermos", "canteen", "picnic",
+  "blanket", "pillow", "cushion", "quilt", "mattress", "curtain", "doormat", "carpet", "rug", "wallpaper",
+  "otter", "pangolin", "heron", "narwhal", "axolotl", "marmot", "badger", "beaver", "bobcat", "capybara",
+  "chinchilla", "dormouse", "echidna", "ferret", "gecko", "gibbon", "hedgehog", "ibex", "jackal", "kestrel",
+  "lemur", "lynx", "manatee", "meerkat", "mongoose", "newt", "ocelot", "okapi", "opossum", "panther",
+  "platypus", "porpoise", "quokka", "raccoon", "salamander", "seahorse", "stingray", "tapir", "toucan", "wallaby",
+  "walrus", "weasel", "wombat", "wolverine", "aardvark", "albatross", "alpaca", "anteater", "antelope", "armadillo",
+  "barnacle", "buffalo", "bullfrog", "caribou", "cheetah", "chipmunk", "cormorant", "cougar", "coyote", "cricket",
+  "dolphin", "dragonfly", "duckling", "falcon", "firefly", "flamingo", "gazelle", "giraffe", "goldfish", "grasshopper",
+  "hamster", "hummingbird", "jaguar", "jellyfish", "kangaroo", "kingfisher", "koala", "ladybug", "leopard", "lobster",
+  "magpie", "mallard", "mantis", "minnow", "mockingbird", "octopus", "ostrich", "panda", "parakeet", "peacock",
+  "pelican", "penguin", "pheasant", "porcupine", "puffin", "reindeer", "rooster", "seagull", "skylark", "sparrow",
+  "squirrel", "starling", "sturgeon", "swallow", "tadpole", "tortoise", "trout", "turtle", "vulture", "warbler",
+  "woodpecker", "oblivion", "ennui", "monotony", "silence", "entropy", "solitude", "reverie", "nostalgia", "whimsy",
+  "wonder", "yearning", "longing", "sorrow", "melancholy", "serenity", "tranquility", "euphoria", "languor", "torpor",
+  "stillness", "quietude", "emptiness", "vacancy", "absence", "infinity", "eternity", "destiny", "fortune", "chance",
+  "freedom", "wisdom", "courage", "patience", "kindness", "gratitude", "harmony", "balance", "mystery", "secret",
+  "riddle", "enigma", "paradox", "echo", "shadow", "glimmer", "whisper", "murmur", "hush", "lull",
+  "drift", "haze", "mirage", "illusion", "fantasy", "daydream", "slumber", "dawning", "twilight", "gloaming",
+  "meadow", "glacier", "canyon", "thicket", "lagoon", "prairie", "marsh", "grove", "glade", "fjord",
+  "delta", "estuary", "tundra", "savanna", "wetland", "heath", "moor", "fen", "bog", "dune",
+  "ridge", "ravine", "gorge", "gully", "plateau", "mesa", "butte", "foothill", "summit", "valley",
+  "hillside", "riverbank", "seashore", "shoreline", "coastline", "tidepool", "waterfall", "cascade", "brook", "creek",
+  "stream", "rivulet", "spring", "pond", "lake", "oasis", "reef", "atoll", "island", "peninsula",
+  "boulder", "pebble", "cavern", "grotto", "hollow", "clearing", "woodland", "forest", "rainforest", "jungle",
+  "orchard", "vineyard", "wildflower", "fern", "blossom", "petal", "willow", "birch", "cedar", "maple",
+  "nebula", "comet", "quasar", "eclipse", "horizon", "galaxy", "starlight", "moonbeam", "sunbeam", "aurora",
+  "cosmos", "meteor", "asteroid", "planet", "satellite", "constellation", "supernova", "starburst", "stardust", "cosmonaut",
+  "moonrise", "zenith", "nadir", "equinox", "solstice", "crescent", "corona", "nightfall", "daybreak", "sunrise",
+  "sunset", "afterglow", "starfall", "skyline", "firmament", "biscuit", "marmalade", "dumpling", "custard", "pretzel",
+  "muffin", "crumpet", "scone", "waffle", "pancake", "croissant", "baguette", "brioche", "focaccia", "sourdough",
+  "doughnut", "cupcake", "brownie", "cookie", "macaroon", "meringue", "truffle", "praline", "caramel", "toffee",
+  "fudge", "nougat", "marzipan", "gingerbread", "shortbread", "strudel", "cobbler", "trifle", "parfait", "sherbet",
+  "popsicle", "lollipop", "gumdrop", "jellybean", "marshmallow", "porridge", "oatmeal", "granola", "pudding", "tapioca",
+  "noodle", "ravioli", "dumplings", "wonton", "sushi", "tempura", "empanada", "quesadilla", "burrito", "taco",
+  "falafel", "hummus", "pickle", "relish", "chutney", "ketchup", "mustard", "gravy", "cinnamon", "nutmeg",
+  "paprika", "ginger", "vanilla", "honey", "molasses", "syrup", "jam", "jelly", "cubicle", "hallway",
+  "lighthouse", "observatory", "bazaar", "atrium", "balcony", "corridor", "stairwell", "mezzanine", "veranda", "portico",
+  "rotunda", "alcove", "foyer", "pantry", "cellar", "attic", "loft", "gazebo", "pavilion", "pagoda",
+  "turret", "battlement", "drawbridge", "rampart", "parapet", "colonnade", "archway", "courtyard", "cloister", "sanctuary",
+  "chapel", "cathedral", "monastery", "windmill", "watermill", "granary", "barn", "silo", "stable", "cottage",
+  "cabin", "bungalow", "chalet", "villa", "manor", "mansion", "palace", "fortress", "citadel", "outpost",
+  "harbor", "wharf", "pier", "dock", "jetty", "marina", "aqueduct", "viaduct", "tunnel", "bridge",
+  "skyscraper", "tenement", "plaza", "promenade", "boulevard", "alleyway", "crossroads", "junction", "roundabout", "terminal",
+  "depot", "station", "carousel", "ferriswheel", "bandstand", "amphitheater", "arena", "stadium", "colosseum", "planetarium",
+  "aquarium", "conservatory", "greenhouse", "apiary", "aviary", "dovecote", "beacon", "monument", "obelisk", "fountain",
+  "cannister", "decanter", "goblet", "chalice", "carafe", "tureen", "platter", "saucer", "teaspoon", "saltcellar",
+  "candlestick", "chandelier", "sundial", "hourglass", "barometer", "metronome", "gramophone", "phonograph", "accordion", "harmonica",
+  "tambourine", "kazoo", "ocarina", "zither", "mandolin", "banjo", "ukulele", "trombone", "trumpet", "clarinet",
+  "harpsichord", "glockenspiel", "periscope", "kaleidoscope", "spyglass", "monocle", "spectacles", "goggles", "mitten", "scarf"
+]);
+
+export const SURNAMES = clean([
+  "einstein", "turing", "curie", "lovelace", "hopper", "tesla", "darwin", "newton", "bohr", "hawking",
+  "noether", "ramanujan", "euler", "gauss", "hypatia", "galileo", "kepler", "copernicus", "faraday", "maxwell",
+  "feynman", "planck", "heisenberg", "schrodinger", "dirac", "fermi", "pauli", "rutherford", "thomson", "chadwick",
+  "becquerel", "roentgen", "compton", "millikan", "oppenheimer", "sagan", "herschel", "huygens", "brahe", "laplace",
+  "lagrange", "fourier", "pascal", "fermat", "leibniz", "cauchy", "riemann", "cantor", "hilbert", "poincare",
+  "boole", "fibonacci", "pythagoras", "archimedes", "euclid", "ptolemy", "hubble", "chandrasekhar", "penzias", "wilson",
+  "mendel", "linnaeus", "lamarck", "wallace", "pasteur", "koch", "fleming", "salk", "jenner", "lister",
+  "harvey", "vesalius", "mendeleev", "lavoisier", "dalton", "avogadro", "boyle", "priestley", "arrhenius", "gibbs",
+  "joule", "kelvin", "carnot", "helmholtz", "ohm", "ampere", "volta", "coulomb", "henry", "watt",
+  "edison", "morse", "bell", "marconi", "wright", "whitney", "fulton", "goodyear", "gutenberg", "franklin",
+  "tycho", "aristotle", "democritus", "ada", "babbage", "shannon", "neumann", "godel", "markov", "bayes",
+  "bernoulli", "napier", "kovalevskaya", "germain", "banneker", "carver", "tyson", "goodall", "leakey", "fossey",
+  "humboldt", "magellan", "columbus", "cook", "drake", "amundsen", "shackleton", "livingstone", "cousteau", "hillary",
+  "armstrong", "gagarin", "ride", "jemison", "tereshkova", "aldrin"
+]);
+
+const RESERVED = new Set(["p", "index", "404", ""]);
+const DNS_LABEL = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+const MAX_LENGTH = 63;
+
+// A small mulberry32 PRNG. Cryptographic strength is NOT needed — names are
+// cosmetic, not a secret — but a seedable generator makes tests deterministic.
+// Returns a function yielding floats in [0, 1).
+export function makeRng(seed) {
+  let a = seed >>> 0;
+  return function next() {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Default randomness: uniform, unbiased picks via crypto.randomInt (still a Node
+// builtin, so zero npm deps).
+function cryptoRng() {
+  return randomInt(0, 0x100000000) / 0x100000000;
+}
+
+function pick(list, rng) {
+  return list[Math.floor(rng() * list.length)];
+}
+
+function pickDistinct(list, rng, notEqualTo) {
+  for (let i = 0; i < 8; i += 1) {
+    const value = pick(list, rng);
+    if (value !== notEqualTo) return value;
+  }
+  return pick(list, rng);
+}
+
+// Name shapes, mixing flavors so the library reads with lots of variety.
+const TEMPLATES = [
+  (rng) => [pick(ADJECTIVES, rng), pick(NOUNS, rng)],                              // hollow-paperclip
+  (rng) => [pick(ADVERBS, rng), pick(ADJECTIVES, rng), pick(NOUNS, rng)],          // dreamily-fading-casket
+  (rng) => {                                                                       // hushed-restless-oblivion
+    const first = pick(ADJECTIVES, rng);
+    return [first, pickDistinct(ADJECTIVES, rng, first), pick(NOUNS, rng)];
+  },
+  (rng) => [pick(ADJECTIVES, rng), pick(SURNAMES, rng)],                           // nostalgic-curie
+  (rng) => [pick(ADVERBS, rng), pick(ADJECTIVES, rng), pick(SURNAMES, rng)]        // quietly-restless-turing
+];
+
+// Generate one memorable name. Pass { template } to force a specific shape (0-4)
+// and { rng } (e.g. makeRng(seed)) for deterministic output in tests.
+export function generateName({ rng = cryptoRng, template } = {}) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const build = template === undefined ? pick(TEMPLATES, rng) : TEMPLATES[template];
+    const name = build(rng).join("-");
+    if (name.length <= MAX_LENGTH && !RESERVED.has(name) && DNS_LABEL.test(name)) {
+      return name;
+    }
+  }
+  // Always-valid fallback (two short words can never exceed the cap or collide
+  // with a reserved single-segment slug).
+  return `${pick(ADJECTIVES, rng)}-${pick(NOUNS, rng)}`;
+}
+
+// Generate a name that is not already taken. `isTaken(name)` should return true
+// for any slug already in use. The huge library makes a clash unlikely, but if
+// every reroll collides we escalate by appending another word — never a digit —
+// so the result stays all-words and is guaranteed unique and terminating.
+export function generateUniqueName(isTaken = () => false, { rng = cryptoRng, generate } = {}) {
+  const gen = generate || (() => generateName({ rng }));
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const name = gen();
+    if (!isTaken(name)) return name;
+  }
+  let name = gen();
+  for (let guard = 0; guard < 100 && isTaken(name); guard += 1) {
+    const candidate = `${name}-${pick(NOUNS, rng)}`;
+    name = candidate.length <= MAX_LENGTH ? candidate : gen();
+  }
+  return name;
+}

--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,7 @@ import { randomBytes } from "node:crypto";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { markdownToHtml } from "./markdown.js";
+import { generateUniqueName } from "./nameGenerator.js";
 import {
   isValidPasswordHash,
   makePasswordHash,
@@ -168,10 +169,20 @@ function createReportId(fileName) {
   return `${slugifyReportName(fileName)}-${randomBytes(4).toString("hex")}`;
 }
 
-function createPublicToken(label) {
-  // 16 bytes = 128 bits of entropy. The unguessable token IS the access-control
-  // model for /p/<token>/ links, so keep it well beyond brute-forceable.
-  return `${slugifyReportName(label)}-${randomBytes(16).toString("hex")}`;
+// Recover the human-readable name from a public token. New tokens ARE the name
+// (e.g. "hollow-paperclip"); this also strips the trailing "-<32 hex>" tail from
+// any legacy token (e.g. "v1-<hex>" -> "v1") so old and new compare cleanly.
+export function publicTokenNamePrefix(token) {
+  return String(token || "").replace(/-[0-9a-f]{32}$/i, "");
+}
+
+// A published page's URL slug is now a memorable all-words name with NO random
+// tail (e.g. /p/hollow-paperclip/). Uniqueness comes from the very large word
+// library plus a per-publish collision check (isNameTaken); see nameGenerator.js.
+// NOTE: without the old entropy tail the slug is guessable, so it is no longer an
+// access-control boundary — sensitive pages must use password protection.
+export function createPublicToken(isNameTaken = () => false) {
+  return generateUniqueName(isNameTaken);
 }
 
 function isPathInside(rootDir, targetPath) {
@@ -2646,7 +2657,18 @@ export function createReportStore({
 
     const createdAt = nowIso();
     const cleanLabel = slugifyReportName(label || nextPublicationLabel(report));
-    const token = createPublicToken(cleanLabel);
+    // The slug now carries no random tail, so it must be unique on its own.
+    // Collect every existing slug (and any legacy name prefix) and re-roll the
+    // generated name until it does not collide.
+    const takenNames = new Set();
+    for (const existing of reports.values()) {
+      for (const publication of existing.publications || []) {
+        const slug = publication.slug || publication.token;
+        takenNames.add(slug);
+        takenNames.add(publicTokenNamePrefix(slug));
+      }
+    }
+    const token = createPublicToken((name) => takenNames.has(name));
     const publication = {
       token,
       slug: token,

--- a/src/server.js
+++ b/src/server.js
@@ -2663,9 +2663,23 @@ export function createReportStore({
     const takenNames = new Set();
     for (const existing of reports.values()) {
       for (const publication of existing.publications || []) {
-        const slug = publication.slug || publication.token;
-        takenNames.add(slug);
-        takenNames.add(publicTokenNamePrefix(slug));
+        // Reserve the token AND the slug (and their name prefixes). A renamed
+        // publication keeps its original `token` as its identity even though the
+        // `slug` changed, so reserving only the slug would let the old token be
+        // reissued and break findPublication/revoke/sync.
+        const tokenName = publication.token;
+        const slugName = publication.slug || tokenName;
+        for (const name of [tokenName, slugName, publicTokenNamePrefix(tokenName), publicTokenNamePrefix(slugName)]) {
+          if (name) takenNames.add(name);
+        }
+      }
+    }
+    // Renamed slugs leave a /p/<old>/ redirect; reserve those too, since a new
+    // slug equal to an old redirect source would silently steal that route.
+    for (const entry of redirects) {
+      const fromMatch = /^\/p\/([^/]+)\/?$/.exec(entry.from);
+      if (fromMatch) {
+        takenNames.add(decodeURIComponent(fromMatch[1]));
       }
     }
     const token = createPublicToken((name) => takenNames.has(name));

--- a/test/name-generator.test.js
+++ b/test/name-generator.test.js
@@ -101,3 +101,14 @@ test("generateUniqueName escalates with extra words when names keep colliding", 
     assert.match(part, /^[a-z]+$/, `escalated part "${part}" is not a word`);
   }
 });
+
+test("generateName throws on an out-of-range template index", () => {
+  assert.throws(() => generateName({ template: 99 }), RangeError);
+  assert.throws(() => generateName({ template: -1 }), RangeError);
+});
+
+test("generateUniqueName throws rather than return a taken slug when exhausted", () => {
+  // If literally every candidate collides, returning one would break the
+  // token-identity contract — so it must throw instead.
+  assert.throws(() => generateUniqueName(() => true), /unique name/);
+});

--- a/test/name-generator.test.js
+++ b/test/name-generator.test.js
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ADVERBS,
+  ADJECTIVES,
+  NOUNS,
+  SURNAMES,
+  generateName,
+  generateUniqueName,
+  makeRng
+} from "../src/nameGenerator.js";
+
+const DNS_LABEL = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+const HEX_TAIL = /-[0-9a-f]{32}$/;
+const RESERVED = new Set(["p", "index", "404", ""]);
+
+test("generateName always produces a valid DNS-label slug with no random tail", () => {
+  for (let i = 0; i < 5000; i += 1) {
+    const name = generateName();
+    assert.match(name, DNS_LABEL, `"${name}" is not a valid DNS label`);
+    assert.ok(name.length <= 63, `"${name}" exceeds 63 chars`);
+    assert.ok(!name.startsWith("-") && !name.endsWith("-"), `"${name}" has a boundary hyphen`);
+    assert.ok(!name.includes("--"), `"${name}" has a double hyphen`);
+    assert.equal(name, name.toLowerCase(), `"${name}" is not lowercase`);
+    assert.doesNotMatch(name, HEX_TAIL, `"${name}" still has a hex tail`);
+    assert.ok(!RESERVED.has(name), `"${name}" is a reserved slug`);
+  }
+});
+
+test("names are 2 or 3 real-word parts", () => {
+  for (let i = 0; i < 1000; i += 1) {
+    const parts = generateName().split("-");
+    assert.ok(parts.length === 2 || parts.length === 3, `unexpected part count: ${parts.length}`);
+    for (const part of parts) {
+      assert.match(part, /^[a-z]+$/, `part "${part}" is not pure lowercase letters`);
+    }
+  }
+});
+
+test("templates draw from the expected word lists", () => {
+  const adjNoun = generateName({ template: 0, rng: makeRng(1) }).split("-");
+  assert.equal(adjNoun.length, 2);
+  assert.ok(ADJECTIVES.includes(adjNoun[0]) && NOUNS.includes(adjNoun[1]));
+
+  const advAdjNoun = generateName({ template: 1, rng: makeRng(2) }).split("-");
+  assert.equal(advAdjNoun.length, 3);
+  assert.ok(ADVERBS.includes(advAdjNoun[0]));
+
+  const adjSurname = generateName({ template: 3, rng: makeRng(3) }).split("-");
+  assert.equal(adjSurname.length, 2);
+  assert.ok(ADJECTIVES.includes(adjSurname[0]) && SURNAMES.includes(adjSurname[1]));
+});
+
+test("the library is really large (>100M combinations)", () => {
+  assert.ok(ADVERBS.length >= 200, `only ${ADVERBS.length} adverbs`);
+  assert.ok(ADJECTIVES.length >= 450, `only ${ADJECTIVES.length} adjectives`);
+  assert.ok(NOUNS.length >= 550, `only ${NOUNS.length} nouns`);
+  assert.ok(SURNAMES.length >= 120, `only ${SURNAMES.length} surnames`);
+  // The adverb-adjective-noun shape alone clears 50 million...
+  assert.ok(ADVERBS.length * ADJECTIVES.length * NOUNS.length > 50_000_000);
+  // ...and the adjective-adjective-noun shape clears 100 million on its own.
+  assert.ok(ADJECTIVES.length * (ADJECTIVES.length - 1) * NOUNS.length > 100_000_000);
+});
+
+test("output is varied — no degenerate repetition", () => {
+  const seen = new Set();
+  for (let i = 0; i < 3000; i += 1) {
+    seen.add(generateName());
+  }
+  assert.ok(seen.size > 2800, `only ${seen.size} unique names in 3000 draws`);
+});
+
+test("makeRng makes generateName deterministic for tests", () => {
+  const a = makeRng(12345);
+  const b = makeRng(12345);
+  const seqA = Array.from({ length: 30 }, () => generateName({ rng: a }));
+  const seqB = Array.from({ length: 30 }, () => generateName({ rng: b }));
+  assert.deepEqual(seqA, seqB, "same seed should yield the same name sequence");
+
+  const c = makeRng(99999);
+  const seqC = Array.from({ length: 30 }, () => generateName({ rng: c }));
+  assert.notDeepEqual(seqA, seqC, "different seeds should diverge");
+});
+
+test("generateUniqueName re-rolls past a taken name", () => {
+  const sequence = ["hollow-paperclip", "vacant-otter", "calm-comet"];
+  let i = 0;
+  const generate = () => sequence[i++];
+  const token = generateUniqueName((name) => name === "hollow-paperclip", { generate });
+  assert.equal(token, "vacant-otter", "should skip the taken name and use the next");
+});
+
+test("generateUniqueName escalates with extra words when names keep colliding", () => {
+  // Treat any name with fewer than 4 parts as taken; the only escape is to
+  // append words. The result must therefore grow to >= 4 parts (no digits).
+  const token = generateUniqueName((name) => name.split("-").length < 4);
+  const parts = token.split("-");
+  assert.ok(parts.length >= 4, `expected escalation to >=4 words, got "${token}"`);
+  for (const part of parts) {
+    assert.match(part, /^[a-z]+$/, `escalated part "${part}" is not a word`);
+  }
+});

--- a/test/public-token.test.js
+++ b/test/public-token.test.js
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createPublicToken, publicTokenNamePrefix } from "../src/server.js";
+
+const HEX_TAIL = /-[0-9a-f]{32}$/;
+
+test("createPublicToken is an all-words memorable slug with no random tail", () => {
+  for (let i = 0; i < 500; i += 1) {
+    const token = createPublicToken();
+    assert.doesNotMatch(token, HEX_TAIL, `"${token}" still carries a hex tail`);
+    const parts = token.split("-");
+    assert.ok(parts.length >= 2, `"${token}" should be at least two words`);
+    for (const part of parts) {
+      assert.match(part, /^[a-z]+$/, `part "${part}" is not pure lowercase letters`);
+    }
+    assert.ok(token.length <= 63);
+  }
+});
+
+test("createPublicToken re-rolls until the name is not taken", () => {
+  // isNameTaken reports the first 5 candidates as taken; createPublicToken must
+  // keep generating, so it is called at least 6 times before returning.
+  let calls = 0;
+  const token = createPublicToken(() => {
+    calls += 1;
+    return calls <= 5;
+  });
+  assert.ok(calls >= 6, `expected re-rolls, isNameTaken called ${calls} times`);
+  assert.match(token, /^[a-z]+(?:-[a-z]+)+$/, `"${token}" is not a clean word name`);
+});
+
+test("publicTokenNamePrefix strips a legacy entropy tail but leaves clean names alone", () => {
+  const hex = "a".repeat(32);
+  // Legacy "<name>-<32hex>" tokens reduce to their name.
+  assert.equal(publicTokenNamePrefix(`v1-${hex}`), "v1");
+  assert.equal(publicTokenNamePrefix(`quietly-fading-casket-${hex}`), "quietly-fading-casket");
+  // New tail-free names are returned unchanged.
+  assert.equal(publicTokenNamePrefix("hollow-paperclip"), "hollow-paperclip");
+  assert.equal(publicTokenNamePrefix("nostalgic-curie"), "nostalgic-curie");
+  assert.equal(publicTokenNamePrefix(""), "");
+});
+
+test("a fresh token round-trips through publicTokenNamePrefix unchanged", () => {
+  const token = createPublicToken();
+  assert.equal(publicTokenNamePrefix(token), token, "tail-free token should be its own name");
+});


### PR DESCRIPTION
## What

Published reports now get a quirky, memorable, **all-words** URL slug instead of the old `v1-<32 hex>` token.

```
Before:  /p/v1-efd6e14aa05bc0fe3bf29af406165ce5/
After:   /p/hollow-paperclip/
         /p/befuddled-yearning-infinity/
         /p/tropical-coulomb/
         /p/honeyed-gutenberg/
```

(URL-format change, not an admin-UI rendering change — before/after shown above as text.)

## Why

The random hex tail read as ugly/unusable. These names are friendlier to share, in the spirit of ngrok / localtunnel / Heroku / Docker random names — but with a much larger, multi-theme library and **no digits**.

## How

- **`src/nameGenerator.js`** *(new)* — vendored, **zero-dependency** word library: **220 adverbs × 474 adjectives × 580 nouns + 136 scientist surnames**, spanning existential/mood, whimsical, color, texture, size, weather, cosmic, and "famous scientist" themes. Five name templates (e.g. `adjective-noun`, `adverb-adjective-noun`, `adjective-surname`) give **>100M combinations**. Exposes `generateName`, `generateUniqueName`, `makeRng`.
- **`src/server.js`** — `createPublicToken` now delegates to `generateUniqueName`; new `publicTokenNamePrefix` still strips legacy `-<32hex>` tails; `draftPublication` collects existing slugs and re-rolls on collision, with an all-words escalation fallback that guarantees uniqueness and termination.
- **`package.json`** — `check` script now syntax-checks the new module.
- **Tests** — `test/name-generator.test.js`, `test/public-token.test.js`.

## Security trade-off (intentional)

Without the 128-bit entropy tail, a slug is **guessable** and is **no longer an access-control boundary**. Sensitive pages must use the existing **password protection**. This was an explicit product decision (clean names > URL-obscurity); flagged loudly in code comments and the commit body.

## Verification

`npm run check` ✅ and `npm test` ✅ — **135/135 pass**, including all existing publish-flow tests (token-shape change is backward-compatible; legacy hex tokens still resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amal-david/pagecast/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public report links now use readable, word-based names instead of random-looking suffixes.
  * Generated links are kept unique by checking for conflicts before creating them.

* **Bug Fixes**
  * Improved handling of older link formats so existing public URLs continue to work.
  * Added stronger validation to keep generated names short, clean, and URL-safe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->