### PR TITLE
Release 0.2.0: memorable URLs, Docker, deploy history, telemetry

### DIFF
--- a/.codex/skills/publish-report/SKILL.md
+++ b/.codex/skills/publish-report/SKILL.md
@@ -1,81 +1,135 @@
 ---
 name: publish-report
 description: Publish local HTML, Markdown, or built static web projects with Pagecast as shareable public URLs. Use whenever Codex creates or finishes an .html, .htm, .md, .markdown, or static build output that a person could share (a report, plan, doc, dashboard, or analysis) — proactively offer to publish it without being asked — and whenever the user asks to publish, share, make a public link for, or send a local report/doc/dashboard/web project from terminal, Codex CLI, or Codex desktop.
+version: 0.4.0
 ---
 
-# Publish With Pagecast
+# Publish with Pagecast
 
-## Overview
+Pagecast turns a local **HTML or Markdown** file (a report, plan, doc, or
+dashboard) into a shareable public URL backed by the user's Cloudflare Pages
+project. Use this skill to offer that at the right moment, then do it on a yes.
 
-Use Pagecast to turn a finished local artifact into a shareable public URL backed
-by the user's Cloudflare Pages project. Prefer `pagecast publish <file>` for
-reports, docs, and built entry files. Use `pagecast publish site <dir>` only when
-the user intentionally wants to deploy a whole static folder to a named
-Cloudflare Pages project.
+## When to offer
 
-Never publish without explicit confirmation. Publishing makes the selected
-artifact publicly reachable.
+**Default to offering.** Whenever you produce an `.html`/`.htm` or
+`.md`/`.markdown` file that a person could reasonably share, proactively offer to
+publish it — once, right after you finish making it. Do **not** wait to be asked,
+and do **not** stay silent because you are unsure whether it is "worth it." If it
+could be shared, offer.
 
-## Be Proactive
+This includes:
 
-**Default to offering.** Right after you create or finish a shareable file, offer
-once to publish it — do not wait for the user to ask, and do not stay silent
-because you are unsure it is "worth it." If it could be shared, offer. When it is
-borderline, offer anyway; the user can say no.
+- A report you generated — test/coverage/Lighthouse/Playwright output, a data
+  dashboard, an analysis, a "here's what I built/found" summary.
+- A written plan, proposal, design doc, spec, release notes, or doc.
+- A static web project that was just built, with a generated entry file such as
+  `dist/index.html`, `build/index.html`, `out/index.html`, or `public/index.html`.
+- Any time the user says "share", "publish", "make a link for", or "send" a doc.
 
-## What To Publish
+**The only files to skip** (don't offer): scratch/draft notes the user is clearly
+keeping private, source code, config files, secrets, and repo-meta files (README,
+CHANGELOG, CONTRIBUTING, LICENSE, AGENTS.md, CLAUDE.md, TODO/tasks), or anything
+under `node_modules`/`dist` build internals. When it is borderline, **offer** —
+the user can just say no.
 
-Proactively offer once for any shareable artifact you produce:
+Ask **at most once per file.** If the user declines or ignores the offer, drop it
+and don't re-ask for that file. Never nag across multiple turns.
 
-- HTML reports, dashboards, coverage reports, Playwright/Lighthouse output, or
-  static single-page mini apps.
-- Markdown reports, plans, docs, proposals, release notes, analyses, or summaries
-  meant to be read by someone else. (A plan you just finished can be shared too —
-  write it to a `.md` file first, then publish that path.)
-- Static web projects after they are built. Publish the generated entry file,
-  usually `dist/index.html`, `build/index.html`, `out/index.html`, or
-  `public/index.html`; Pagecast stages sibling assets from that output folder.
+## The one question to ask
 
-Only skip (do not offer) clearly non-shareable files: scratch/draft notes the
-user is keeping private, source files, repo metadata (README/CHANGELOG,
-AGENTS.md/CLAUDE.md), task files, secrets, config files, dependency/build
-folders, and hidden files.
+> "Want me to publish this with Pagecast? It'll create a shareable public link."
 
-## Confirmation
+Only on an explicit **yes** do you proceed. Publishing makes the file publicly
+reachable — **never publish without confirmation.**
 
-Ask one direct question before publishing:
+## How to publish
 
-```text
-Want me to publish this with Pagecast?
-```
-
-Proceed only after an explicit yes. If the user declines or ignores the offer,
-drop it and do not ask again for that artifact.
-
-## Headless CLI Workflow
-
-Resolve the target to an absolute path, then run:
+Run the headless CLI with the **absolute path** and `--json`:
 
 ```sh
-npx pagecast publish "/absolute/path/to/report-or-built-index.html" --json
+npx pagecast publish "/absolute/path/to/file.md" --json
 ```
 
-Markdown works too:
+(HTML and Markdown both work — Markdown is rendered to a clean page. If `pagecast`
+is installed globally/in the project, `pagecast publish "<path>" --json` is the same.)
+
+Published links use **memorable word-slugs** (e.g. `/p/hollow-paperclip/`) and are
+long and hard to guess (private) by default. The user can rename a link — or make a
+short, shareable "drop" link — from the `npx pagecast` app.
+
+### Publish options
+
+Add any of these to a `publish` command:
+
+- `--expires <7d|12h|never>` — edge-enforced link expiry (default 30d). The page
+  returns 410 once expired; `--expires never` keeps it live until revoked. The
+  result JSON reports `expiresAt` (or none when never).
+- `--password "<pw>"` — gate the page behind a password, enforced at the edge so
+  every file of a multi-file report is covered. `--no-password` removes protection.
+  The result JSON reports `passwordProtected: true`.
+- `--label "<name>"` — set the page's display name in the Pagecast app.
 
 ```sh
-npx pagecast publish "/absolute/path/to/report.md" --json
+npx pagecast publish "/absolute/path/to/report.html" --expires 7d --password "hunter2" --json
 ```
 
-For a web project that should get a new shareable `/p/<token>/` link:
+**Publishing a plan** (e.g. after plan mode): the plan lives in your context, not
+a file yet. If the user wants it shared, first write the plan markdown to a file
+(e.g. `./plan.md`), then publish that path. Don't overwrite an existing file the
+user cares about — pick a clear new name.
 
-1. Run the project's existing build command, such as `npm run build`, only if the
-   user expects the current project state to be published.
-2. Find the static output entry file, usually `dist/index.html`,
-   `build/index.html`, `out/index.html`, or `public/index.html`.
-3. Publish that entry file with `npx pagecast publish "<absolute-entry-path>" --json`.
+## Live goal / progress page
 
-If the user asks to deploy or update an entire static site/project rather than
-create a new share link, deploy the built folder directly:
+When you're working toward a **`/goal`** (a long autonomous run the user can't
+easily watch), the user often can't see what's happening. Proactively **offer
+once**:
+
+> "Want me to publish a live progress page for this goal? You'll get a public
+> link you can open anytime to see status and what's done."
+
+On an explicit **yes**:
+
+1. Write a `pagecast-goal.md` in the working dir with the goal, status, a
+   done/next checklist, and a one-line "latest", e.g.:
+   ```markdown
+   # <short goal title>
+
+   **Goal:** <the goal condition, in your own words>
+   **Status:** In progress · updated <time>
+   **Progress:** 3 / 8 steps
+
+   ## Done
+   - [x] <step>
+
+   ## Next
+   - [ ] <step>
+
+   ## Latest
+   <one line: what you just did / any blocker>
+   ```
+2. Run `npx pagecast goal publish "<abs path>/pagecast-goal.md" --json` and give
+   the user the returned `url`.
+3. **After each meaningful step**, rewrite `pagecast-goal.md` and re-run the
+   **same** `npx pagecast goal publish … --json` — it updates the **same URL** in
+   place (do NOT use plain `publish`, which mints a new link each time).
+4. When the goal is met, do a final update; optionally `npx pagecast goal stop`.
+
+There is one goal page per workspace. If a command reports `recreated: true`, the
+old link was gone and the URL changed — tell the user the new URL.
+
+## Static web projects
+
+For a static web project that should get a new shareable `/p/<slug>/` link, build
+first and publish the generated entry file:
+
+```sh
+npm run build
+npx pagecast publish "/absolute/path/to/dist/index.html" --json
+```
+
+If the user asks to deploy or update an entire static site/project, deploy the
+built folder directly to a named Cloudflare Pages project:
 
 ```sh
 npx pagecast publish site "/absolute/path/to/dist" --project "project-name" --branch main --json
@@ -88,26 +142,30 @@ npx pagecast pages deploy "/absolute/path/to/dist" --project "project-name" --js
 ```
 
 Use this instead of raw Wrangler commands like `npx wrangler pages deploy`.
-Direct site deploys replace the target Cloudflare Pages project contents, so do
-not guess the `--project`; use the user's named project or ask for it.
+Direct site deploys replace the target Pages project contents, so do not guess
+the `--project`; use the user's named project or ask for it.
 
-Parse stdout as JSON:
+## Reading the result
 
-- Success: `{ "ok": true, "url": "https://<project>.pages.dev/p/<token>/", ... }`
-  Return the `url` and mention that the user can rename, re-sync, or revoke it
-  from `npx pagecast`.
-- `401`: the user has not connected Cloudflare. Tell them to run
-  `npx pagecast pages setup` once, or run `npx pagecast` and click
-  **Connect Cloudflare**, then retry if they want.
-- `409`: multiple Cloudflare accounts are available. Tell them to run
-  `npx pagecast pages setup --account <account-id>` once, or run `npx pagecast`
-  and choose the account, then retry.
-- Other errors: relay the error concisely and do not claim success.
+Parse the JSON on stdout:
 
-## Cloudflare Pages Workflow
+- **Success** → `{ "ok": true, "url": "https://<project>.pages.dev/p/<slug>/", ... }`
+  - Give the user the `url`. Mention they can rename the URL, re-sync, or revoke it
+    from `npx pagecast`.
+- **Not signed in** → `{ "ok": false, "statusCode": 401, ... }`
+  - This is the one-time setup. Tell the user to run **`npx pagecast pages setup`**
+    once, or run **`npx pagecast`** and click **Connect Cloudflare**, then offer to
+    retry. After that, publishing is headless — a plain "yes" is enough every time.
+- **Multiple accounts** → `{ "ok": false, "statusCode": 409, ... }`
+  - Tell the user to run `npx pagecast pages setup --account <account-id>` once, or
+    run `npx pagecast` to pick which Cloudflare account to publish from, then retry.
+- **Any other error** → relay `error` concisely and offer to retry. Do not claim
+  success.
+
+## Cloudflare Pages commands
 
 Use these lower-level commands when the user explicitly asks about Cloudflare
-setup or project deployment:
+setup, status, project listing, or direct Pages deployment:
 
 ```sh
 npx pagecast pages setup --project "project-name" --json
@@ -119,48 +177,16 @@ npx pagecast pages deploy "/absolute/path/to/dist" --project "project-name" --br
 If the user does not specify a branch, omit `--branch`; Pagecast deploys to
 `main`.
 
-`pages deploy` is the Pagecast abstraction over `npx wrangler pages deploy`; it
-passes the account to Wrangler internally through `CLOUDFLARE_ACCOUNT_ID` when
-needed.
+## Codex usage notes
 
-## Live Goal / Progress Page
-
-When working toward a `/goal` (a long autonomous run the user can't easily watch),
-proactively offer once: "Want me to publish a live progress page you can check
-anytime?" On an explicit yes:
-
-1. Write a `pagecast-goal.md` with the goal, status, a done/next checklist, and a
-   one-line "latest".
-2. `npx pagecast goal publish "/abs/pagecast-goal.md" --json` → give the user the
-   `url`.
-3. After each meaningful step, rewrite the file and re-run the **same** command —
-   it updates the **same URL** in place. Do NOT use plain `publish` (mints a new
-   link). `npx pagecast goal stop` when done.
-
-One goal page per workspace; if a result has `recreated: true`, the URL changed —
-surface the new one.
-
-## App Workflow
-
-Use the app when the user needs to manage folders or existing links:
-
-```sh
-npx pagecast
-```
-
-The app opens at `http://127.0.0.1:4173` and supports:
-
-- Adding HTML/Markdown files.
-- Adding deployable static folders.
-- Adding source folders with an explicit build command and output directory.
-- Publishing, renaming, re-syncing, and revoking URLs.
-
-## Codex Usage Notes
-
-- From Codex CLI or desktop, run terminal commands in the user's current project
-  directory so `.pagecast/` config and publish history stay with that project.
-- Always use absolute paths in `pagecast publish` and `pagecast pages deploy`.
-- If the user asks only for a command, provide the command and any one-time setup
-  note instead of running it.
-- If the user asks Codex to publish, run the command after confirmation and
-  report the resulting URL or exact failure.
+- Always pass an **absolute** path (resolve relative paths against the cwd first).
+- Run terminal commands in the user's current project directory so the `.pagecast/`
+  config and publish history stay with that project.
+- The first publish auto-creates the user's Pages project — no manual setup beyond
+  the one-time Connect Cloudflare login.
+- If the user asks only for a command, provide the command (and any one-time setup
+  note) instead of running it. If they ask Codex to publish, run it after
+  confirmation and report the resulting URL or the exact failure.
+- To update a page **in place at the same URL**, the user can re-sync from the
+  Pagecast app; re-running `publish` mints a new link. Old links keep working until
+  revoked.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to Pagecast are documented here. This project follows
+[semantic versioning](https://semver.org/).
+
+## 0.2.0 — 2026-06-26
+
+### Added
+
+- **Memorable links** — published pages now get human-readable word-slugs
+  (e.g. `/p/hollow-paperclip/`) instead of a random token tail. Links are
+  long and hard-to-guess (private) by default. (#10)
+- **Advanced publish settings** — a "Publish as a drop" toggle in the admin UI
+  mints a short, shareable (guessable) link; the default stays a long,
+  hard-to-guess private link. (#11)
+- **Docker support** — a single image runs the dashboard *and* every
+  publish/deploy command. Ships a Dockerfile, Compose file, and headless CLI
+  usage with a scoped `CLOUDFLARE_API_TOKEN`. (#9)
+- **Deploy history** — view and remove old whole-site Cloudflare Pages
+  deployment snapshots from the admin UI (**Settings → Deploy history**) or the
+  terminal: `pagecast pages deployments list|delete|prune`. (#6)
+- **Anonymous usage telemetry (opt-out)** — reports only the command name,
+  pagecast/Node version, and OS/arch; never file contents, paths, published
+  URLs, or Cloudflare tokens. Off in CI by default; disable with
+  `pagecast telemetry disable`, `PAGECAST_TELEMETRY=0`, or `DO_NOT_TRACK=1`. (#12)
+
+### Fixed
+
+- **Windows compatibility** — spawn `npx` via the shell and accept Windows-style
+  paths so publish and deploy work on Windows. (#8)
+
+## 0.1.6
+
+- **Expiring URLs** — edge-enforced link expiry (default 30d, configurable via
+  `--expires <7d|12h|never>`), enforced by a generated Cloudflare Pages
+  Function. (#5)

--- a/README.md
+++ b/README.md
@@ -54,8 +54,11 @@ npx pagecast pages setup --project pagecast
 ## Publish From The Terminal
 
 ```sh
-# An HTML or Markdown file → a /p/<token>/ link (sibling assets included)
+# An HTML or Markdown file → a memorable /p/<slug>/ link (sibling assets included)
 npx pagecast publish "/absolute/path/report.html" --json
+
+# Set an expiry — 7d, 12h, or never (default 30d)
+npx pagecast publish "/absolute/path/report.html" --expires 7d --json
 
 # A built static project → publish its entry file
 npm run build && npx pagecast publish "$(pwd)/dist/index.html" --json
@@ -64,9 +67,12 @@ npm run build && npx pagecast publish "$(pwd)/dist/index.html" --json
 npx pagecast pages deploy "$(pwd)/dist" --project pagecasthq --json
 ```
 
-Add `--json` for agents and CI. Use the admin UI for link renaming, re-sync,
-revoke, and build settings. Common errors: `statusCode 401` → run `pages setup`
-or connect Cloudflare; `statusCode 409` → pass `--account <id>`.
+Links use human-readable word-slugs (e.g. `/p/hollow-paperclip/`) and are long
+and hard to guess (private) by default; the admin UI's **Publish as a drop**
+toggle mints a short, shareable link instead. Add `--json` for agents and CI,
+and use the admin UI for link renaming, re-sync, revoke, and build settings.
+Common errors: `statusCode 401` → run `pages setup` or connect Cloudflare;
+`statusCode 409` → pass `--account <id>`.
 
 ## Password Protection
 
@@ -192,7 +198,7 @@ See [extension/README.md](extension/README.md).
 ## Security Model
 
 - Admin UI binds to `127.0.0.1`; draft previews are local-only.
-- Public access only through active `/p/<token>/` links; revoked tokens 404 after
+- Public access only through active `/p/<slug>/` links; revoked links 404 after
   the redeploy finishes.
 - Public routes reject directory traversal and hidden files. Sibling assets in a
   report's folder can become public if referenced — keep secrets out of it.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagecast",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "type": "module",
   "description": "Preview local HTML reports and static mini apps, then publish them to shareable URLs.",
   "license": "MIT",

--- a/plugin/skills/publish-report/SKILL.md
+++ b/plugin/skills/publish-report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: publish-report
 description: Use right after an HTML or Markdown report, plan, doc, dashboard, or built static web project is created (or when the user wants to share one). Proactively offer to publish it with Pagecast as a shareable public link, then return the URL. Default to offering; only skip clearly internal/scratch files.
-version: 0.3.0
+version: 0.4.0
 ---
 
 # Publish with Pagecast
@@ -56,6 +56,26 @@ npx pagecast publish "/absolute/path/to/file.md" --json
 (HTML and Markdown both work — Markdown is rendered to a clean page. If `pagecast`
 is installed globally/in the project, `pagecast publish "<path>" --json` is the same.)
 
+Published links use **memorable word-slugs** (e.g. `/p/hollow-paperclip/`) and are
+long and hard to guess (private) by default. The user can rename a link — or make a
+short, shareable "drop" link — from the `npx pagecast` app.
+
+### Publish options
+
+Add any of these to a `publish` command:
+
+- `--expires <7d|12h|never>` — edge-enforced link expiry (default 30d). The page
+  returns 410 once expired; `--expires never` keeps it live until revoked. The
+  result JSON reports `expiresAt` (or none when never).
+- `--password "<pw>"` — gate the page behind a password, enforced at the edge so
+  every file of a multi-file report is covered. `--no-password` removes protection.
+  The result JSON reports `passwordProtected: true`.
+- `--label "<name>"` — set the page's display name in the Pagecast app.
+
+```sh
+npx pagecast publish "/absolute/path/to/report.html" --expires 7d --password "hunter2" --json
+```
+
 **Publishing a plan** (e.g. after plan mode): the plan lives in your context, not
 a file yet. If the user wants it shared, first write the plan markdown to a file
 (e.g. `./plan.md`), then publish that path. Don't overwrite an existing file the
@@ -100,7 +120,7 @@ On an explicit **yes**:
 There is one goal page per workspace. If a command reports `recreated: true`, the
 old link was gone and the URL changed — tell the user the new URL.
 
-For static web projects that should get a new shareable `/p/<token>/` link,
+For static web projects that should get a new shareable `/p/<slug>/` link,
 build first and publish the generated entry file:
 
 ```sh
@@ -127,7 +147,7 @@ the `--project`; use the user's named project or ask for it.
 
 Parse the JSON on stdout:
 
-- **Success** → `{ "ok": true, "url": "https://<project>.pages.dev/p/<token>/", ... }`
+- **Success** → `{ "ok": true, "url": "https://<project>.pages.dev/p/<slug>/", ... }`
   - Give the user the `url`. Offer to drop it into a PR/Slack message, and
     mention they can rename the URL, re-sync, or revoke it from `npx pagecast`.
 - **Not signed in** → `{ "ok": false, "statusCode": 401, ... }`


### PR DESCRIPTION
Bumps `pagecast` **0.1.6 → 0.2.0** to publish the work merged since the `v0.1.6` tag, and refreshes the `publish-report` skill so coding agents know about (and use) the new capabilities.

## Release notes (0.2.0)

**Added**
- **Memorable links** (#10) — published pages get human-readable word-slugs (e.g. `/p/hollow-paperclip/`) instead of a random token tail. Long & hard-to-guess (private) by default.
- **Advanced publish settings** (#11) — admin-UI **"Publish as a drop"** toggle mints a short, shareable link; default stays a long private one.
- **Docker support** (#9) — one image serves the dashboard *and* runs every publish/deploy command (Dockerfile, Compose, headless CLI).
- **Deploy history** (#6) — view/remove old whole-site Pages snapshots from the admin UI or `pagecast pages deployments list|delete|prune`.
- **Anonymous usage telemetry, opt-out** (#12) — command name + version + OS/arch only; off in CI by default.

**Fixed**
- **Windows compatibility** (#8) — spawn `npx` via shell, accept Windows paths.

## Skill refresh (`publish-report`)
- Documents `--expires <7d|12h|never>`, `--password "<pw>"` / `--no-password`, and `--label "<name>"`.
- Explains the memorable, private-by-default link model (was: random tokens).
- Aligns the two shipped copies (`.codex/` ↔ `plugin/`) and bumps both to `version: 0.4.0`.

## Docs
- `CHANGELOG.md` added with `0.2.0` + backfilled `0.1.6`.
- README: corrected stale `/p/<token>/` → `/p/<slug>/` and documented `--expires`.

## Verification
- `npm run check` ✓
- `npm test` ✓ (165 tests pass)
- `npm pack --dry-run` ✓ — `pagecast-0.2.0.tgz` includes both `publish-report` SKILL.md files.

## Releasing
After merge, publishing a **GitHub Release** at `v0.2.0` triggers the npm publish workflow (reads the version from `package.json`). The `CHANGELOG.md` `0.2.0` block is ready to paste into the release body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amal-david/pagecast/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for human-readable share links, including updated publish and status workflows.
  * Documented additional publish options for expiration, password protection, and labels.
  * Added guidance for publishing static sites and updating live goal pages.

* **Bug Fixes**
  * Clarified Windows and path-handling guidance for command-line publishing.
  * Improved error-handling instructions for sign-in and multiple-account issues.

* **Documentation**
  * Expanded the README and changelog with updated release and security details.
  * Bumped project and skill version references to `0.2.0` and `0.4.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->