### PR TITLE
docs: show the Deploy history screenshot in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ security model, and caveats: [PASSWORD-PROTECTION.md](PASSWORD-PROTECTION.md).
 
 ## Deploy History
 
+<p align="center">
+  <img src="media/screenshots/deploy-history.png" alt="Pagecast admin UI: Settings → Deploy history listing whole-site deployment snapshots, newest first, with the live snapshot delete-protected and a keep-newest-N cleanup" width="460">
+</p>
+
 Every publish or re-sync creates a new Cloudflare Pages deployment — an immutable
 snapshot of your whole site at that moment, each with its own `<hash>.pages.dev`
 URL. Over time these pile up. View and remove them from the admin UI


### PR DESCRIPTION
The README's **Deploy History** section had no image. This embeds the annotated `media/screenshots/deploy-history.png` (already tracked, added in d6b5af5) right under that heading.

- Centered `<p align="center">` to match the admin hero shot.
- Sized **460px** (not the hero's 900) since it's a tall portrait panel (1240×1910).
- Alt text describes the live-snapshot protection and keep-newest-N cleanup the annotations call out.

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amal-david/pagecast/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Deploy History section in the README with a screenshot of the Deploy history view.
  * Improved the image description to better explain the layout and key behaviors shown in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->