### PR TITLE
Add stdio MCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,48 @@ cp plugin/skills/publish-report/SKILL.md /path/to/your-agent/skills/publish-repo
 
 More detail in [plugin/README.md](plugin/README.md).
 
+## Use Through MCP
+
+Pagecast can also run as a Model Context Protocol server, so MCP-capable agents
+can publish files or generated HTML/Markdown content without shelling out to the
+CLI themselves.
+
+For local agents, use the stdio server:
+
+```json
+{
+  "mcpServers": {
+    "pagecast": {
+      "command": "npx",
+      "args": ["pagecast", "mcp"]
+    }
+  }
+}
+```
+
+The MCP server exposes tools for status, listing known pages, publishing supplied
+HTML/Markdown content, publishing a local file, and revoking a publication token.
+It uses the same `.pagecast/` config, Cloudflare credentials, expiry, and
+password-protection behavior as `npx pagecast publish`.
+
+For safety, `publish_content` is the preferred MCP path: the supplied content is
+written into isolated Pagecast storage before publishing. `publish_file` also
+isolates the entry file by default; if you need sibling assets from the file's
+folder, pass `includeAssets: true` and `confirmAssets: true` because referenced
+files from that folder may become public.
+
+The MCP server is intentionally separate from the admin API. The admin API can
+run local publish/build work and should stay loopback-only. Do not expose the
+admin port to a VPN or shared network.
+
+Important: this first MCP surface is stdio-only. An org-hosted HTTP MCP endpoint
+or VPN-only publishing target should be added in a follow-up with a dedicated
+threat model, audit logging, and an access-control story. Putting a future MCP
+endpoint behind a VPN would control who can invoke Pagecast; it would not by
+itself make the returned published URL VPN-only. For private recipients today,
+use Pagecast password protection or protect the Pages/custom domain with your
+org's access layer.
+
 ## Run with Docker
 
 A single image bundles the whole `pagecast` CLI, so it serves the admin dashboard

--- a/llms.txt
+++ b/llms.txt
@@ -34,6 +34,7 @@ Use `pagecast --help` to confirm the current interface.
 - List deployment snapshots: `npx pagecast pages deployments list --json`
 - Delete one deployment snapshot: `npx pagecast pages deployments delete <id> --json`
 - Prune old snapshots, keeping the newest N: `npx pagecast pages deployments prune --keep 5 --yes --json`
+- Run local MCP over stdio: `npx pagecast mcp`
 
 ## Notes for agents
 
@@ -46,6 +47,10 @@ Use `pagecast --help` to confirm the current interface.
 - `--branch` is optional for direct site deploys; Pagecast uses `main` by default.
 - Do not call raw `npx wrangler pages deploy` unless Pagecast is unavailable or the user explicitly asks for Wrangler.
 - `pages deployments delete`/`prune` permanently remove whole-site snapshots; confirm with the user first. The live deployment is protected and `prune` requires `--keep <N>` plus `--yes` for non-interactive runs.
+- MCP tools: `status`, `list_pages`, `publish_file`, `publish_content`, and `revoke_publication`.
+- Prefer MCP `publish_content`; MCP `publish_file` excludes sibling assets unless called with `includeAssets: true` and `confirmAssets: true`.
+- MCP `revoke_publication` requires `confirm: true` in the tool arguments.
+- Keep the Pagecast admin API loopback-only. Hosted HTTP MCP and VPN-only publishing are follow-up hardening work, not part of the first MCP surface.
 
 ## Error handling
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "start": "node src/cli.js",
     "build": "pnpm -C web install --frozen-lockfile --ignore-scripts && pnpm -C web run build",
-    "check": "node --check src/server.js && node --check src/cli.js && node --check src/local-system.js && node --check src/markdown.js && node --check src/nameGenerator.js",
+    "check": "node --check src/server.js && node --check src/cli.js && node --check src/mcp.js && node --check src/local-system.js && node --check src/markdown.js && node --check src/nameGenerator.js",
     "test": "node --test",
     "prepack": "npm run build && npm run check && npm test",
     "prepublishOnly": "npm run check && npm test"

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -52,6 +52,27 @@ The portable `SKILL.md` is the Agent-Skills format. The detection hook is
 Claude-Code-specific; elsewhere the skill still triggers when a report is created
 or when you ask to publish one.
 
+### MCP-capable agents
+
+If your agent supports MCP, you can connect it directly to Pagecast instead of
+copying a skill file:
+
+```json
+{
+  "mcpServers": {
+    "pagecast": {
+      "command": "npx",
+      "args": ["pagecast", "mcp"]
+    }
+  }
+}
+```
+
+This first MCP integration is stdio-only. Keep the Pagecast admin API private;
+do not expose the admin port to a VPN or shared network. A hosted HTTP MCP
+endpoint should be a separate hardening pass with its own authentication and
+audit model.
+
 ### 2. Connect Cloudflare
 
 ```sh

--- a/src/cli.js
+++ b/src/cli.js
@@ -37,6 +37,7 @@ import {
   launchGuiDomain,
   pfRulesTargetPortMatches
 } from "./local-system.js";
+import { startMcpStdioServer } from "./mcp.js";
 import { classifyCommand, createReporter, resolveTelemetry } from "./telemetry.js";
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -367,6 +368,7 @@ const VALUE_FLAGS = new Set([
   "account",
   "account-id",
   "branch",
+  "data-dir",
   "expires",
   "host",
   "keep",
@@ -882,6 +884,23 @@ async function publish(args) {
   }
 }
 
+async function mcp(args) {
+  const explicitSubcommand = args[0] && !args[0].startsWith("--") ? args[0] : "stdio";
+  const rest = explicitSubcommand === "stdio" && args[0]?.startsWith("--") ? args : args.slice(1);
+  const subcommand = explicitSubcommand;
+  const parsed = parseFlags(rest);
+  const mcpDataDir = optionValue(parsed, "data-dir") || dataDir;
+
+  if (subcommand === "stdio") {
+    await startMcpStdioServer({ dataDir: mcpDataDir, version: packageVersion });
+    return;
+  }
+
+  console.error(`Unknown mcp command: ${subcommand || ""}\n`);
+  usage();
+  process.exit(1);
+}
+
 async function deploySite(args, parsed = parseFlags(args)) {
   const json = wantsJson(parsed);
   const sourceDir = parsed.positionals[0];
@@ -1189,6 +1208,7 @@ function usage() {
       "  pagecast goal publish <file> [--slug goal] [--json]   Publish/update a live goal-progress page",
       "  pagecast goal status [--json]                         Show the current goal page",
       "  pagecast goal stop [--json]                           Take the goal page offline",
+      "  pagecast mcp [stdio] [--data-dir <dir>]                Run a local stdio MCP server",
       "  pagecast telemetry status [--json]                    Show anonymous-usage-telemetry state",
       "  pagecast telemetry enable|disable                     Turn anonymous usage telemetry on/off",
       "  pagecast --help                                       Show this help"
@@ -1204,6 +1224,13 @@ async function run() {
   // (avoids phoning home on the very command used to opt out).
   if (command === "telemetry") {
     await telemetry(rest);
+    return;
+  }
+
+  // MCP uses stdout as a protocol stream, so start it before any telemetry setup
+  // or user-facing output that could corrupt JSON-RPC framing.
+  if (command === "mcp") {
+    await mcp(rest);
     return;
   }
 

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -495,12 +495,18 @@ export function createPagecastMcpServer({
 }
 
 export function startMcpStdioServer(options = {}) {
-  const server = createPagecastMcpServer(options);
+  const {
+    input = process.stdin,
+    output = process.stdout,
+    server: providedServer
+  } = options;
+  const server = providedServer || createPagecastMcpServer(options);
   let buffer = "";
+  let queue = Promise.resolve();
 
   return new Promise((resolve, reject) => {
-    process.stdin.setEncoding("utf8");
-    process.stdin.on("data", (chunk) => {
+    input.setEncoding("utf8");
+    input.on("data", (chunk) => {
       buffer += chunk;
       const lines = buffer.split(/\r?\n/);
       buffer = lines.pop() || "";
@@ -509,11 +515,14 @@ export function startMcpStdioServer(options = {}) {
         if (!trimmed) {
           continue;
         }
-        void handleLine(trimmed);
+        queue = queue.then(() => handleLine(trimmed), () => handleLine(trimmed));
+        void queue.catch(reject);
       }
     });
-    process.stdin.on("end", resolve);
-    process.stdin.on("error", reject);
+    input.on("end", () => {
+      queue.then(resolve, reject);
+    });
+    input.on("error", reject);
   });
 
   async function handleLine(line) {
@@ -521,7 +530,7 @@ export function startMcpStdioServer(options = {}) {
     try {
       message = JSON.parse(line);
     } catch (error) {
-      process.stdout.write(
+      output.write(
         `${JSON.stringify({
           jsonrpc: "2.0",
           id: null,
@@ -533,7 +542,7 @@ export function startMcpStdioServer(options = {}) {
 
     const response = await server.handleJsonRpc(message);
     if (response) {
-      process.stdout.write(`${JSON.stringify(response)}\n`);
+      output.write(`${JSON.stringify(response)}\n`);
     }
   }
 }

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -1,0 +1,539 @@
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import {
+  MAX_UPLOAD_BYTES,
+  appError,
+  createReportStore,
+  getCloudflarePagesStatus,
+  publishReportSnapshot,
+  revokeReportPublication
+} from "./server.js";
+
+const DEFAULT_MCP_PROTOCOL_VERSION = "2025-06-18";
+const CONTENT_EXTENSIONS = new Set([".html", ".htm", ".md", ".markdown"]);
+
+class JsonRpcError extends Error {
+  constructor(code, message, data) {
+    super(message);
+    this.code = code;
+    this.data = data;
+  }
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function textResult(value) {
+  return {
+    content: [
+      {
+        type: "text",
+        text: typeof value === "string" ? value : JSON.stringify(value, null, 2)
+      }
+    ]
+  };
+}
+
+function errorResult(error) {
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text: error?.message || String(error)
+      }
+    ]
+  };
+}
+
+function requiredString(args, name) {
+  const value = args?.[name];
+  if (typeof value !== "string" || !value.trim()) {
+    throw appError(`\`${name}\` is required.`, 400);
+  }
+  return value.trim();
+}
+
+function requiredContent(args) {
+  const value = args?.content;
+  if (typeof value !== "string" || !value.trim()) {
+    throw appError("`content` is required.", 400);
+  }
+  return value;
+}
+
+function optionalString(args, name) {
+  const value = args?.[name];
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+function optionalBoolean(args, name) {
+  return args?.[name] === true;
+}
+
+function normalizeContentFileName({ filename, format }) {
+  const requestedFormat = String(format || "").trim().toLowerCase();
+  const defaultExtension = requestedFormat === "markdown" || requestedFormat === "md" ? ".md" : ".html";
+  const rawBase = path.basename(String(filename || `pagecast-mcp-content${defaultExtension}`).trim());
+  const extension = path.extname(rawBase).toLowerCase() || defaultExtension;
+  if (!CONTENT_EXTENSIONS.has(extension)) {
+    throw appError("Content filename must end in .html, .htm, .md, or .markdown.", 400);
+  }
+  const name = path.basename(rawBase, path.extname(rawBase)).replace(/[^A-Za-z0-9._-]+/g, "-");
+  return `${name || "pagecast-mcp-content"}${extension}`;
+}
+
+async function writeMcpContentFile({ dataDir, content, filename, format }) {
+  if (typeof content !== "string" || !content.trim()) {
+    throw appError("`content` is required.", 400);
+  }
+  if (Buffer.byteLength(content, "utf8") > MAX_UPLOAD_BYTES) {
+    throw appError("Content is too large for MCP publishing.", 413);
+  }
+  const safeName = normalizeContentFileName({ filename, format });
+  const contentDir = path.join(dataDir, "mcp-content", `${Date.now()}-${randomUUID()}`);
+  await fs.mkdir(contentDir, { recursive: true });
+  const filePath = path.join(contentDir, safeName);
+  await fs.writeFile(filePath, content, "utf8");
+  return filePath;
+}
+
+function normalizeToolArguments(params) {
+  const args = isObject(params?.arguments) ? params.arguments : {};
+  return args;
+}
+
+function summarizeStatus(status) {
+  const cloudflare = status?.cloudflare || {};
+  return {
+    configured: Boolean(cloudflare.loggedIn || cloudflare.tokenConfigured),
+    loggedIn: Boolean(cloudflare.loggedIn),
+    tokenConfigured: Boolean(cloudflare.tokenConfigured),
+    projectName: cloudflare.projectName || "",
+    baseUrl: cloudflare.baseUrl || ""
+  };
+}
+
+function summarizePublication(publication) {
+  return {
+    token: publication.token,
+    slug: publication.slug,
+    label: publication.label,
+    kind: publication.kind,
+    active: publication.active,
+    publicUrl: publication.publicUrl,
+    expiresAt: publication.expiresAt,
+    expired: publication.expired,
+    revokedAt: publication.revokedAt
+  };
+}
+
+function summarizeReport(report) {
+  return {
+    id: report.id,
+    name: report.name,
+    kind: report.kind,
+    publicUrl: report.publicUrl,
+    passwordProtected: report.passwordProtected,
+    createdAt: report.createdAt,
+    updatedAt: report.updatedAt,
+    publications: (report.publications || []).map(summarizePublication)
+  };
+}
+
+async function publishIsolatedFile({ dataDir, filePath, args, publishFile, writeContentFile }) {
+  normalizeContentFileName({ filename: path.basename(filePath) });
+  const content = await fs.readFile(filePath, "utf8");
+  const isolatedPath = await writeContentFile({
+    dataDir,
+    content,
+    filename: path.basename(filePath)
+  });
+  const result = await publishFile({
+    path: isolatedPath,
+    label: optionalString(args, "label") || path.basename(filePath),
+    password: optionalString(args, "password"),
+    disableProtection: optionalBoolean(args, "noPassword"),
+    expires: optionalString(args, "expires"),
+    dataDir
+  });
+  return { ...result, sourcePath: isolatedPath, includedAssets: false };
+}
+
+function toolDefinitions() {
+  return [
+    {
+      name: "status",
+      title: "Pagecast Status",
+      description: "Show Pagecast Cloudflare Pages configuration and sign-in state.",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          verbose: { type: "boolean", description: "Return full local config metadata instead of a redacted summary." }
+        }
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false
+      }
+    },
+    {
+      name: "list_pages",
+      title: "List Pagecast Pages",
+      description: "List locally known Pagecast reports and published links.",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          verbose: { type: "boolean", description: "Include local source paths and build settings." }
+        }
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false
+      }
+    },
+    {
+      name: "publish_file",
+      title: "Publish File",
+      description: "Publish a local HTML or Markdown file with Pagecast. Sibling assets are excluded unless explicitly requested.",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        required: ["path"],
+        properties: {
+          path: { type: "string", description: "Absolute path to an HTML or Markdown file." },
+          label: { type: "string", description: "Optional Pagecast display label." },
+          expires: { type: "string", description: "Expiry such as 7d, 12h, or never." },
+          password: { type: "string", description: "Optional password for edge protection." },
+          noPassword: { type: "boolean", description: "Remove existing password protection for this file." },
+          includeAssets: { type: "boolean", description: "Publish sibling assets from the file's folder." },
+          confirmAssets: {
+            type: "boolean",
+            description: "Must be true with includeAssets because sibling files may become public."
+          }
+        }
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true
+      }
+    },
+    {
+      name: "publish_content",
+      title: "Publish Content",
+      description: "Write HTML or Markdown content into Pagecast storage and publish it.",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        required: ["content"],
+        properties: {
+          content: { type: "string", description: "HTML or Markdown content to publish." },
+          filename: { type: "string", description: "Optional filename ending in .html, .htm, .md, or .markdown." },
+          format: { type: "string", enum: ["html", "markdown"], description: "Used to choose a default extension." },
+          label: { type: "string", description: "Optional Pagecast display label." },
+          expires: { type: "string", description: "Expiry such as 7d, 12h, or never." },
+          password: { type: "string", description: "Optional password for edge protection." },
+          noPassword: { type: "boolean", description: "Remove existing password protection for this content filename." }
+        }
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true
+      }
+    },
+    {
+      name: "revoke_publication",
+      title: "Revoke Publication",
+      description: "Revoke a Pagecast publication token and redeploy the Pages site.",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        required: ["token", "confirm"],
+        properties: {
+          token: { type: "string", description: "Pagecast publication token." },
+          confirm: { type: "boolean", description: "Must be true because this takes a live link offline." }
+        }
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true
+      }
+    }
+  ];
+}
+
+export function createPagecastMcpServer({
+  dataDir = path.join(process.cwd(), ".pagecast"),
+  version = "0.0.0",
+  getStatus = getCloudflarePagesStatus,
+  publishFile = publishReportSnapshot,
+  revokePublication = revokeReportPublication,
+  createStore = createReportStore,
+  writeContentFile = writeMcpContentFile
+} = {}) {
+  async function listPages() {
+    const store = createStore({ dataDir });
+    await store.init();
+    return { reports: store.list({}) };
+  }
+
+  async function readResource(uri) {
+    if (uri === "pagecast://status") {
+      return summarizeStatus(await getStatus({ dataDir }));
+    }
+    if (uri === "pagecast://pages") {
+      const pages = await listPages();
+      return { reports: pages.reports.map(summarizeReport) };
+    }
+    throw new JsonRpcError(-32602, `Unknown resource: ${uri}`);
+  }
+
+  async function callTool(name, args) {
+    if (name === "status") {
+      const status = await getStatus({ dataDir });
+      return textResult(args.verbose === true ? status : summarizeStatus(status));
+    }
+    if (name === "list_pages") {
+      const pages = await listPages();
+      return textResult(args.verbose === true ? pages : { reports: pages.reports.map(summarizeReport) });
+    }
+    if (name === "publish_file") {
+      if (args.password && args.noPassword) {
+        throw appError("Use either `password` or `noPassword`, not both.", 400);
+      }
+      const filePath = requiredString(args, "path");
+      if (args.includeAssets === true && args.confirmAssets !== true) {
+        throw appError("Set `confirmAssets: true` with `includeAssets` because sibling files may become public.", 400);
+      }
+      if (args.includeAssets !== true) {
+        return textResult(
+          await publishIsolatedFile({
+            dataDir,
+            filePath,
+            args,
+            publishFile,
+            writeContentFile
+          })
+        );
+      }
+      const result = await publishFile({
+        path: filePath,
+        label: optionalString(args, "label"),
+        password: optionalString(args, "password"),
+        disableProtection: optionalBoolean(args, "noPassword"),
+        expires: optionalString(args, "expires"),
+        dataDir
+      });
+      return textResult({ ...result, includedAssets: true });
+    }
+    if (name === "publish_content") {
+      if (args.password && args.noPassword) {
+        throw appError("Use either `password` or `noPassword`, not both.", 400);
+      }
+      const filePath = await writeContentFile({
+        dataDir,
+        content: requiredContent(args),
+        filename: optionalString(args, "filename"),
+        format: optionalString(args, "format")
+      });
+      const result = await publishFile({
+        path: filePath,
+        label: optionalString(args, "label") || path.basename(filePath),
+        password: optionalString(args, "password"),
+        disableProtection: optionalBoolean(args, "noPassword"),
+        expires: optionalString(args, "expires"),
+        dataDir
+      });
+      return textResult({ ...result, sourcePath: filePath });
+    }
+    if (name === "revoke_publication") {
+      if (args.confirm !== true) {
+        throw appError("Set `confirm: true` to revoke a live Pagecast link.", 400);
+      }
+      const result = await revokePublication({
+        token: requiredString(args, "token"),
+        dataDir
+      });
+      return textResult({
+        report: summarizeReport(result.report),
+        publication: summarizePublication(result.publication)
+      });
+    }
+    throw new JsonRpcError(-32601, `Unknown tool: ${name}`);
+  }
+
+  function success(id, result) {
+    return { jsonrpc: "2.0", id, result };
+  }
+
+  function failure(id, error) {
+    const code = Number.isInteger(error?.code) ? error.code : -32000;
+    const payload = {
+      code,
+      message: error?.message || String(error)
+    };
+    if (error?.data !== undefined) {
+      payload.data = error.data;
+    }
+    return { jsonrpc: "2.0", id: id ?? null, error: payload };
+  }
+
+  async function handleOne(message) {
+    if (!isObject(message)) {
+      return failure(null, new JsonRpcError(-32600, "Invalid JSON-RPC message."));
+    }
+
+    const id = Object.hasOwn(message, "id") ? message.id : undefined;
+    const method = typeof message.method === "string" ? message.method : "";
+    const params = isObject(message.params) ? message.params : {};
+    const isNotification = id === undefined;
+
+    try {
+      if (method === "notifications/initialized") {
+        return null;
+      }
+      if (!method) {
+        throw new JsonRpcError(-32600, "JSON-RPC method is required.");
+      }
+      if (method === "initialize") {
+        return success(id, {
+          protocolVersion:
+            typeof params.protocolVersion === "string" && params.protocolVersion
+              ? params.protocolVersion
+              : DEFAULT_MCP_PROTOCOL_VERSION,
+          capabilities: {
+            tools: { listChanged: false },
+            resources: { listChanged: false }
+          },
+          serverInfo: {
+            name: "pagecast",
+            version
+          }
+        });
+      }
+      if (method === "ping") {
+        return success(id, {});
+      }
+      if (method === "tools/list") {
+        return success(id, { tools: toolDefinitions() });
+      }
+      if (method === "tools/call") {
+        const name = requiredString(params, "name");
+        try {
+          return success(id, await callTool(name, normalizeToolArguments(params)));
+        } catch (error) {
+          if (error instanceof JsonRpcError) {
+            throw error;
+          }
+          return success(id, errorResult(error));
+        }
+      }
+      if (method === "resources/list") {
+        return success(id, {
+          resources: [
+            {
+              uri: "pagecast://status",
+              name: "Pagecast status",
+              mimeType: "application/json"
+            },
+            {
+              uri: "pagecast://pages",
+              name: "Pagecast pages",
+              mimeType: "application/json"
+            }
+          ]
+        });
+      }
+      if (method === "resources/read") {
+        const uri = requiredString(params, "uri");
+        return success(id, {
+          contents: [
+            {
+              uri,
+              mimeType: "application/json",
+              text: JSON.stringify(await readResource(uri), null, 2)
+            }
+          ]
+        });
+      }
+      throw new JsonRpcError(-32601, `Method not found: ${method}`);
+    } catch (error) {
+      if (isNotification) {
+        return null;
+      }
+      return failure(id, error);
+    }
+  }
+
+  async function handleJsonRpc(message) {
+    if (Array.isArray(message)) {
+      const responses = (await Promise.all(message.map((entry) => handleOne(entry)))).filter(Boolean);
+      return responses.length > 0 ? responses : null;
+    }
+    return handleOne(message);
+  }
+
+  return {
+    handleJsonRpc,
+    callTool,
+    listTools: toolDefinitions
+  };
+}
+
+export function startMcpStdioServer(options = {}) {
+  const server = createPagecastMcpServer(options);
+  let buffer = "";
+
+  return new Promise((resolve, reject) => {
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      buffer += chunk;
+      const lines = buffer.split(/\r?\n/);
+      buffer = lines.pop() || "";
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          continue;
+        }
+        void handleLine(trimmed);
+      }
+    });
+    process.stdin.on("end", resolve);
+    process.stdin.on("error", reject);
+  });
+
+  async function handleLine(line) {
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch (error) {
+      process.stdout.write(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: null,
+          error: { code: -32700, message: error.message || "Parse error" }
+        })}\n`
+      );
+      return;
+    }
+
+    const response = await server.handleJsonRpc(message);
+    if (response) {
+      process.stdout.write(`${JSON.stringify(response)}\n`);
+    }
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -6321,6 +6321,56 @@ export async function publishReportSnapshot({
   };
 }
 
+export async function revokeReportPublication({
+  token,
+  dataDir = path.join(PROJECT_ROOT, ".pagecast"),
+  cloudflareAuthSpawnImpl = spawn,
+  pagesDeploySpawnImpl = spawn,
+  cloudflareListTimeoutMs = DEFAULT_CLOUDFLARE_LIST_TIMEOUT_MS,
+  pagesDeployTimeoutMs = 180000
+} = {}) {
+  const publicationToken = String(token || "").trim();
+  if (!publicationToken) {
+    throw appError("A publication token is required.", 400);
+  }
+
+  const store = createReportStore({ dataDir });
+  await store.init();
+  const existing = store.findPublication(publicationToken);
+  if (!existing) {
+    throw appError("Published link was not found.", 404);
+  }
+
+  if (!existing.publication.revokedAt && existing.publication.kind === "snapshot") {
+    const { configStore, cloudflareAuth, pagesPublisher } = await createHeadlessCloudflareContext({
+      dataDir,
+      store,
+      cloudflareAuthSpawnImpl,
+      pagesDeploySpawnImpl,
+      cloudflareListTimeoutMs,
+      pagesDeployTimeoutMs
+    });
+    const credential = cloudflareCredentialStatus();
+    if (!credential.tokenConfigured) {
+      const session = await cloudflareAuth.refreshSession();
+      if (!session.loggedIn) {
+        throw appError(cloudflareAuthRequiredMessage(), 401);
+      }
+    }
+    const pagesConfig = pagesConfigForPublication(existing.publication, configStore.get().pages);
+    await pagesPublisher.revoke(
+      [existing.publication.slug || existing.publication.token],
+      pagesConfig
+    );
+  }
+
+  const { report, publication } = await store.revokePublication(publicationToken);
+  return {
+    report: store.formatReport(report, {}),
+    publication: store.formatPublication(publication, {})
+  };
+}
+
 // Publish (or update in place) the live goal-progress page. Idempotent: the first
 // call publishes <file> and records it in config.goal; later calls re-sync the
 // SAME slug/URL with the file's new content (never minting a new link). Stop with

--- a/test/mcp.test.js
+++ b/test/mcp.test.js
@@ -3,10 +3,11 @@ import { spawn } from "node:child_process";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { createPagecastMcpServer } from "../src/mcp.js";
+import { createPagecastMcpServer, startMcpStdioServer } from "../src/mcp.js";
 
 async function makeTempDir() {
   return fs.mkdtemp(path.join(os.tmpdir(), "pagecast-mcp-"));
@@ -333,6 +334,37 @@ test("MCP resources/read returns Pagecast page state", async () => {
   assert.equal(response.result.contents[0].uri, "pagecast://pages");
   const payload = JSON.parse(response.result.contents[0].text);
   assert.deepEqual(payload.reports, []);
+});
+
+test("MCP stdio transport preserves response order for concurrent-looking input", async () => {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  let stdout = "";
+  output.setEncoding("utf8");
+  output.on("data", (chunk) => {
+    stdout += chunk;
+  });
+
+  const server = {
+    async handleJsonRpc(message) {
+      if (message.id === 1) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      return { jsonrpc: "2.0", id: message.id, result: { ok: true } };
+    }
+  };
+
+  const done = startMcpStdioServer({ input, output, server });
+  input.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "slow" })}\n`);
+  input.write(`${JSON.stringify({ jsonrpc: "2.0", id: 2, method: "fast" })}\n`);
+  input.end();
+  await done;
+
+  const ids = stdout
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => JSON.parse(line).id);
+  assert.deepEqual(ids, [1, 2]);
 });
 
 test("CLI mcp stdio emits only JSON-RPC on stdout", async () => {

--- a/test/mcp.test.js
+++ b/test/mcp.test.js
@@ -1,0 +1,373 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { createPagecastMcpServer } from "../src/mcp.js";
+
+async function makeTempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), "pagecast-mcp-"));
+}
+
+function parseToolText(response) {
+  return JSON.parse(response.result.content[0].text);
+}
+
+test("MCP initialize and tools/list expose Pagecast capabilities", async () => {
+  const server = createPagecastMcpServer({ version: "test-version" });
+
+  const initialized = await server.handleJsonRpc({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: { protocolVersion: "2025-06-18" }
+  });
+
+  assert.equal(initialized.result.serverInfo.name, "pagecast");
+  assert.equal(initialized.result.serverInfo.version, "test-version");
+  assert.ok(initialized.result.capabilities.tools);
+  assert.ok(initialized.result.capabilities.resources);
+
+  const tools = await server.handleJsonRpc({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/list"
+  });
+  const names = tools.result.tools.map((tool) => tool.name);
+  assert.deepEqual(
+    names,
+    [
+      "status",
+      "list_pages",
+      "publish_file",
+      "publish_content",
+      "revoke_publication"
+    ]
+  );
+});
+
+test("MCP publish_content writes content then reuses the publish helper", async () => {
+  const dataDir = await makeTempDir();
+  const calls = [];
+  const server = createPagecastMcpServer({
+    dataDir,
+    publishFile: async (input) => {
+      calls.push(input);
+      return {
+        url: "https://pagecast.pages.dev/p/test/",
+        token: "test-token",
+        label: input.label,
+        expiresAt: null
+      };
+    }
+  });
+
+  const response = await server.handleJsonRpc({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: "publish_content",
+      arguments: {
+        content: "# Quarterly Update",
+        filename: "../quarterly.md",
+        label: "Quarterly Update",
+        expires: "7d"
+      }
+    }
+  });
+
+  assert.equal(response.result.isError, undefined);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].dataDir, dataDir);
+  assert.equal(calls[0].label, "Quarterly Update");
+  assert.equal(calls[0].expires, "7d");
+  assert.equal(path.basename(calls[0].path), "quarterly.md");
+  assert.equal(await fs.readFile(calls[0].path, "utf8"), "# Quarterly Update");
+
+  const payload = parseToolText(response);
+  assert.equal(payload.url, "https://pagecast.pages.dev/p/test/");
+  assert.equal(payload.sourcePath, calls[0].path);
+});
+
+test("MCP publish_content preserves the supplied content string", async () => {
+  const dataDir = await makeTempDir();
+  const calls = [];
+  const server = createPagecastMcpServer({
+    dataDir,
+    publishFile: async (input) => {
+      calls.push(input);
+      return { url: "https://pagecast.pages.dev/p/exact/", token: "exact-token" };
+    }
+  });
+  const content = "\n  <h1>Keep my whitespace</h1>\n";
+
+  await server.handleJsonRpc({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: "publish_content",
+      arguments: { content, filename: "exact.html" }
+    }
+  });
+
+  assert.equal(await fs.readFile(calls[0].path, "utf8"), content);
+});
+
+test("MCP tool failures are returned as tool errors, not protocol failures", async () => {
+  const server = createPagecastMcpServer({
+    publishFile: async () => {
+      throw new Error("publish failed");
+    }
+  });
+
+  const response = await server.handleJsonRpc({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: "publish_content",
+      arguments: { content: "<h1>Report</h1>", filename: "report.html" }
+    }
+  });
+
+  assert.equal(response.error, undefined);
+  assert.equal(response.result.isError, true);
+  assert.match(response.result.content[0].text, /publish failed/);
+});
+
+test("MCP unknown tools are protocol errors", async () => {
+  const server = createPagecastMcpServer();
+
+  const response = await server.handleJsonRpc({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: "not_a_tool",
+      arguments: {}
+    }
+  });
+
+  assert.equal(response.result, undefined);
+  assert.equal(response.error.code, -32601);
+});
+
+test("MCP file publishing excludes sibling assets unless explicitly confirmed", async () => {
+  const dataDir = await makeTempDir();
+  const reportDir = path.join(dataDir, "source");
+  await fs.mkdir(reportDir, { recursive: true });
+  const reportPath = path.join(reportDir, "report.html");
+  await fs.writeFile(reportPath, "<h1>Report</h1>");
+  await fs.writeFile(path.join(reportDir, "secret.txt"), "do not publish");
+
+  const calls = [];
+  const server = createPagecastMcpServer({
+    dataDir,
+    publishFile: async (input) => {
+      calls.push(input);
+      return { url: "https://pagecast.pages.dev/p/file/", token: "file-token" };
+    }
+  });
+
+  const isolated = await server.handleJsonRpc({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: "publish_file",
+      arguments: { path: reportPath }
+    }
+  });
+  assert.equal(isolated.result.isError, undefined);
+  assert.equal(calls.length, 1);
+  assert.notEqual(calls[0].path, reportPath);
+  assert.equal(await fs.readFile(calls[0].path, "utf8"), "<h1>Report</h1>");
+  assert.equal(parseToolText(isolated).includedAssets, false);
+
+  const blocked = await server.handleJsonRpc({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "publish_file",
+      arguments: { path: reportPath, includeAssets: true }
+    }
+  });
+  assert.equal(blocked.result.isError, true);
+  assert.match(blocked.result.content[0].text, /confirmAssets: true/);
+});
+
+test("MCP revoke requires explicit confirmation", async () => {
+  const server = createPagecastMcpServer({
+    revokePublication: async () => ({
+      report: {
+        id: "report-1",
+        name: "Report",
+        kind: "path",
+        sourcePath: "/Users/example/secret/report.html",
+        buildCommand: "npm run build",
+        publicUrl: null,
+        passwordProtected: false,
+        publications: []
+      },
+      publication: {
+        token: "abc123",
+        slug: "report",
+        label: "Report",
+        kind: "snapshot",
+        active: false,
+        publicUrl: null,
+        revokedAt: "2026-07-08T00:00:00.000Z"
+      }
+    })
+  });
+
+  const revoke = await server.handleJsonRpc({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: "revoke_publication",
+      arguments: { token: "abc123" }
+    }
+  });
+  assert.equal(revoke.result.isError, true);
+  assert.match(revoke.result.content[0].text, /confirm: true/);
+
+  const confirmed = await server.handleJsonRpc({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "revoke_publication",
+      arguments: { token: "abc123", confirm: true }
+    }
+  });
+  const payload = parseToolText(confirmed);
+  assert.equal(payload.report.sourcePath, undefined);
+  assert.equal(payload.report.buildCommand, undefined);
+  assert.equal(payload.publication.token, "abc123");
+});
+
+test("MCP status and list_pages redact local metadata by default", async () => {
+  const server = createPagecastMcpServer({
+    getStatus: async () => ({
+      cloudflare: {
+        loggedIn: true,
+        tokenConfigured: true,
+        accountName: "Example Org",
+        accountId: "abcdef0123456789abcdef0123456789",
+        accounts: [{ id: "abcdef0123456789abcdef0123456789", name: "Example Org" }],
+        projectName: "pagecast",
+        baseUrl: "https://pagecast.pages.dev"
+      }
+    }),
+    createStore: () => ({
+      init: async () => {},
+      list: () => [
+        {
+          id: "report-1",
+          name: "Report",
+          kind: "path",
+          sourcePath: "/Users/example/secret/report.html",
+          buildCommand: "npm run build",
+          publicUrl: "https://pagecast.pages.dev/p/report/",
+          passwordProtected: false,
+          publications: [
+            {
+              token: "token-1",
+              slug: "report",
+              label: "Report",
+              kind: "snapshot",
+              active: true,
+              publicUrl: "https://pagecast.pages.dev/p/report/"
+            }
+          ]
+        }
+      ]
+    })
+  });
+
+  const status = parseToolText(
+    await server.handleJsonRpc({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "status", arguments: {} }
+    })
+  );
+  assert.equal(status.accountId, undefined);
+  assert.equal(status.accounts, undefined);
+  assert.equal(status.accountName, undefined);
+  assert.equal(status.projectName, "pagecast");
+
+  const pages = parseToolText(
+    await server.handleJsonRpc({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: { name: "list_pages", arguments: {} }
+    })
+  );
+  assert.equal(pages.reports[0].sourcePath, undefined);
+  assert.equal(pages.reports[0].buildCommand, undefined);
+  assert.equal(pages.reports[0].publications[0].token, "token-1");
+});
+
+test("MCP resources/read returns Pagecast page state", async () => {
+  const dataDir = await makeTempDir();
+  const server = createPagecastMcpServer({ dataDir });
+
+  const response = await server.handleJsonRpc({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "resources/read",
+    params: { uri: "pagecast://pages" }
+  });
+
+  assert.equal(response.result.contents[0].uri, "pagecast://pages");
+  const payload = JSON.parse(response.result.contents[0].text);
+  assert.deepEqual(payload.reports, []);
+});
+
+test("CLI mcp stdio emits only JSON-RPC on stdout", async () => {
+  const dataDir = await makeTempDir();
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const child = spawn(process.execPath, ["src/cli.js", "mcp", "--data-dir", dataDir], {
+    cwd: repoRoot,
+    env: { ...process.env, PAGECAST_TELEMETRY: "0" },
+    stdio: ["pipe", "pipe", "pipe"]
+  });
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" })}\n`);
+  child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" })}\n`);
+  child.stdin.end();
+
+  const exitCode = await new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("exit", (code) => resolve(code));
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(stderr, "");
+  const lines = stdout.trim().split(/\r?\n/);
+  assert.equal(lines.length, 2);
+  assert.equal(JSON.parse(lines[0]).id, 1);
+  assert.equal(JSON.parse(lines[1]).id, 2);
+});

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -41,6 +41,7 @@ import {
   parseWranglerWhoamiAccounts,
   parseMultipartUpload,
   publishReportSnapshot,
+  revokeReportPublication,
   setupCloudflarePages,
   startServers
 } from "../src/server.js";
@@ -1373,6 +1374,82 @@ test("Headless publishReportSnapshot auto-provisions and returns a public URL", 
   assert.match(result.url, /^https:\/\/pagecast\.pages\.dev\/p\/.+\/$/);
   assert.equal(result.projectName, "pagecast");
   assert.ok(deployCommands.length >= 1, "expected a Pages deploy");
+});
+
+test("Headless revoke uses the publication's remembered Pages target", async () => {
+  const tempDir = await makeTempDir();
+  const dataDir = path.join(tempDir, "data");
+  const reportDir = path.join(tempDir, "report");
+  await fs.mkdir(reportDir, { recursive: true });
+  const reportPath = path.join(reportDir, "report.html");
+  await fs.writeFile(reportPath, "<h1>Revoke me</h1>");
+
+  const oldAccountId = "11111111111111111111111111111111";
+  const currentAccountId = "22222222222222222222222222222222";
+  const configStore = createConfigStore({ dataDir });
+  await configStore.init();
+  await configStore.updatePages({
+    projectName: "current-project",
+    accountId: currentAccountId,
+    baseUrl: "https://current-project.pages.dev"
+  });
+
+  const store = createReportStore({ dataDir });
+  await store.init();
+  const report = await store.addPath(reportPath);
+  const draft = store.draftPublication(report.id, { kind: "snapshot", label: "Old target" });
+  Object.assign(draft.publication, {
+    slug: "old-target",
+    publicUrl: "https://old-project.pages.dev/p/old-target/",
+    pagesProjectName: "old-project",
+    pagesAccountId: oldAccountId,
+    pagesBaseUrl: "https://old-project.pages.dev"
+  });
+  await store.commitPublication(report.id, draft.publication);
+
+  const previousToken = process.env.CLOUDFLARE_API_TOKEN;
+  const previousAccountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  process.env.CLOUDFLARE_API_TOKEN = "test-token";
+  process.env.CLOUDFLARE_ACCOUNT_ID = currentAccountId;
+  const deployCommands = [];
+  function fakeDeploy(command, args, options) {
+    deployCommands.push({ command, args, accountId: options.env.CLOUDFLARE_ACCOUNT_ID || "" });
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => child.emit("exit", null, "SIGTERM");
+    setImmediate(() => {
+      child.stdout.emit("data", Buffer.from("https://abcdef123456.old-project.pages.dev/"));
+      child.emit("exit", 0, null);
+    });
+    return child;
+  }
+
+  try {
+    await revokeReportPublication({
+      token: draft.publication.token,
+      dataDir,
+      pagesDeploySpawnImpl: fakeDeploy,
+      pagesDeployTimeoutMs: 1000
+    });
+  } finally {
+    if (previousToken === undefined) {
+      delete process.env.CLOUDFLARE_API_TOKEN;
+    } else {
+      process.env.CLOUDFLARE_API_TOKEN = previousToken;
+    }
+    if (previousAccountId === undefined) {
+      delete process.env.CLOUDFLARE_ACCOUNT_ID;
+    } else {
+      process.env.CLOUDFLARE_ACCOUNT_ID = previousAccountId;
+    }
+  }
+
+  assert.ok(deployCommands.length >= 1, "expected revoke to redeploy the Pages site");
+  const deploy = deployCommands.at(-1);
+  assert.equal(deploy.accountId, oldAccountId);
+  assert.ok(deploy.args.includes("old-project"));
+  assert.equal(deploy.args.includes("current-project"), false);
 });
 
 test("Headless Pages site deploy wraps Wrangler with project, branch, and account env", async () => {


### PR DESCRIPTION
## Summary
- add a stdio MCP server for Pagecast with status, list, publish_content, publish_file, revoke, and resource-read support
- wire `pagecast mcp` before telemetry so stdout remains JSON-RPC-only
- add a headless revoke helper that revokes against each publication’s remembered Pages target
- document stdio as the first MCP surface and defer hosted HTTP/VPN-only MCP to a separate hardening pass

## Safety notes
- `publish_content` writes supplied content into isolated Pagecast storage before publishing
- `publish_file` excludes sibling assets unless `includeAssets: true` and `confirmAssets: true` are both set
- default status/list/revoke responses redact local paths, account names, and build commands

## Verification
- `npm run check`
- `npm test` (191 passing)
- `git diff --check`

## Reviews
- CTO/security architecture sub-agent review: approved
- senior implementation/test sub-agent review: approved after confirming new MCP files are tracked
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amal-david/pagecast/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a local `mcp` command to run Pagecast over stdio.
  - Exposed MCP tools and resources for status, listing pages, publishing content/files (with asset safety confirmation), and revoking a publication token.
- **Documentation**
  - Added MCP setup guidance for agents, including safer content publishing behavior and security boundaries for admin access.
- **Bug Fixes**
  - Improved validation to include the MCP entry in the existing `check` workflow.
- **Tests**
  - Added end-to-end MCP and CLI stdio transport coverage, including confirmation/error and metadata-redaction behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->