### PR TITLE
Release Pagecast v0.6.0

### DIFF
--- a/.codex/skills/publish-report/SKILL.md
+++ b/.codex/skills/publish-report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: publish-report
 description: Publish local HTML, Markdown, or built static web projects with Pagecast as shareable public URLs. Use whenever Codex creates or finishes an .html, .htm, .md, .markdown, or static build output that a person could share (a report, plan, doc, dashboard, or analysis) — proactively offer to publish it without being asked — and whenever the user asks to publish, share, make a public link for, or send a local report/doc/dashboard/web project from terminal, Codex CLI, or Codex desktop.
-version: 0.5.0
+version: 0.6.0
 ---
 
 # Publish with Pagecast

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Expected package version (for example 0.5.0 or v0.5.0)
+        description: Expected package version (for example 0.6.0 or v0.6.0)
         required: true
         type: string
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to Pagecast are documented here. This project follows
 
 ## Unreleased
 
+## 0.6.0 — 2026-07-14
+
 ### Added
 
 - **Pagecast Home** — one user-level Cloudflare subdomain and managed state store
@@ -26,7 +28,7 @@ All notable changes to Pagecast are documented here. This project follows
   packaged skills execute them immediately; proactive suggestions still ask.
 - Interactive unauthenticated publishes start Wrangler login and resume the
   original operation. Non-interactive runs fail structurally.
-- **Anonymous CLI telemetry default** — fresh interactive installs now enable
+- **Anonymous CLI telemetry default** — fresh installs now enable
   the existing allowlisted telemetry by default and show a disclosure. Users can
   opt out with `pagecast telemetry disable`, `PAGECAST_TELEMETRY=0`, or
   `DO_NOT_TRACK=1`; CI remains disabled unless explicitly enabled.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -38,7 +38,7 @@ pagecast telemetry disable
 | `command` | `publish`, `pages`, `serve` | Which feature is used |
 | `subcommand` | `deploy`, `status` (allowlisted only) | Which sub-feature is used |
 | `outcome` | `started` | Reserved for success/error signal |
-| `version` | `0.5.0` | Which release is in the field |
+| `version` | `0.6.0` | Which release is in the field |
 | `os`/`arch` | `darwin` / `arm64` | Which platforms to support |
 | `node` | `v22.22.3` | Which Node versions to support |
 | `anonId` | random 32-character hex | Coarse distinct-install counting |

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ backend (export static assets first).
 ## Quick Start
 
 Requires Node.js 20.19+ and a Cloudflare account for publishing. Run the exact
-Pagecast 0.5.0 release without a global install:
+Pagecast 0.6.0 release without a global install:
 
 ```sh
-npx pagecast@0.5.0
+npx pagecast@0.6.0
 ```
 
 The versioned command is reproducible. Unversioned `npx pagecast` follows npm's
@@ -53,30 +53,32 @@ One OS user profile owns one Pagecast Home and Cloudflare subdomain. Run the CLI
 from the relevant project so Pagecast can identify the workspace and source.
 Use `--data-dir` only for an intentionally isolated CI/container profile.
 
-### Upgrading from 0.4 to 0.5
+### Upgrading to 0.6
 
-- Stop any v0.4 foreground process with `Ctrl-C`. For a transient background
+- Stop any older foreground process with `Ctrl-C`. For a transient background
   process, switch versions explicitly:
 
   ```sh
-  npx pagecast@0.4.0 background stop
-  npx pagecast@0.5.0 background start
+  npx pagecast@0.5.0 background stop
+  npx pagecast@0.6.0 background start
   ```
 
 - If you installed the macOS login service, rerun
-  `npx pagecast@0.5.0 background service install`. The LaunchAgent captures the
+  `npx pagecast@0.6.0 background service install`. The LaunchAgent captures the
   exact Node and CLI paths, so restarting the old service does not upgrade it.
-- Replace the unpacked Chrome extension with the matching 0.5.0 release folder
+- Replace the unpacked Chrome extension with the matching 0.6.0 release folder
   (or the `extension/` folder from the same source checkout), then click
-  **Reload** in `chrome://extensions`. The 0.5.0 extension negotiates the new
-  admin-session token before publishing.
-- Existing URLs, passwords, expiries, redirects, Cloudflare selections, and
-  `.pagecast/` data remain readable. Existing word-only URLs are preserved as
-  issued; Pagecast does not silently rotate them.
-- A legacy publication whose Cloudflare account/project was never recorded is
-  readable but cannot be synced, renamed, re-expired, or revoked until you
-  select its original project and click **Attach selected project** for that
-  link.
+  **Reload** in `chrome://extensions`.
+- The first 0.6 launch creates `~/.pagecast/home/` and imports compatible
+  workspace publications without deleting `.pagecast/` state or changing
+  URLs. Publications on other Cloudflare projects remain legacy targets until
+  you explicitly attach or move them.
+- Connect Cloudflare from the main dashboard. Pagecast starts Wrangler's
+  browser authorization, explains the scopes, and resumes setup or publishing
+  after authorization succeeds.
+- Existing URLs, passwords, expiries, redirects, saved telemetry choices, and
+  workspace data remain readable. Enabling Activity analytics provisions the
+  required Cloudflare resources and redeploys active Home publications once.
 - On a genuinely fresh install, anonymous telemetry is enabled by
   default with a one-time disclosure. Disable it with
   `npx pagecast telemetry disable`, `PAGECAST_TELEMETRY=0`, or `DO_NOT_TRACK=1`.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pagecast — Local to Public",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvppHjQcznEeTBkKJU4f6zI+oWt3Z0YH7L+jFbLQ1EsbwKJd9pCyjded9XbC+cITveMupy5yeI424Zs7fKJCUgXMy2OKjRl8ZuNaLC8R3mPTPlgAAnFoZNvo/cSEvnvLi/A/yYPsRPJKT2fXCEIHNyTaXPzBmh30ij4MxVxb3ugNQFu/UKQ07LqAD0M0iDKqC5as9mDvQBi0vo1BgtSLHqJzfWcyWR5lNdLoRD4hUTPsd3I0lrXmrrRa6YYc/L/sYxiIJ1NdZMNnMRr5QUMSkmVZaaGZnVUQB7+ItdoU2duxDsqKo4ljf/yj/lPaCBnNbHp0zD4d/c3OeGG+OZEtUswIDAQAB",
   "description": "Turn a local HTML or Markdown file open in your browser into a public link, via your running Pagecast server.",
   "action": {

--- a/extension/store/SUBMIT.md
+++ b/extension/store/SUBMIT.md
@@ -31,7 +31,7 @@ This zips the extension WITHOUT the `store/` assets and dotfiles. Upload
 `pagecast-extension-v<VERSION>.zip` in the dashboard ("Package" → "Upload new
 package"). Tagged GitHub releases read the same manifest version and use the
 same `pagecast-extension-v<VERSION>.zip` convention, for example
-`pagecast-extension-v0.5.0.zip`.
+`pagecast-extension-v0.6.0.zip`.
 
 ## 3. Privacy practices answers (Web Store form)
 
@@ -62,7 +62,7 @@ same `pagecast-extension-v<VERSION>.zip` convention, for example
 ## 5. Before you submit
 
 - Confirm `extension/manifest.json` matches the npm package and plugin release
-  version. For v0.5 all package-facing metadata is `0.5.0`.
+  version. For v0.6 all package-facing metadata is `0.6.0`.
 - Replace the placeholder developer/brand details as needed.
 - One-time: a Chrome Web Store **developer account** ($5 registration).
 - Test the packaged zip via Load unpacked once more (`chrome://extensions`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagecast",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "description": "Preview local HTML reports and static mini apps, then publish them to shareable URLs.",
   "license": "MIT",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pagecast",
   "displayName": "Pagecast",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "When your agent finishes an HTML or Markdown report, plan, or doc, it asks whether to publish it as a Claude Code Artifact or as a Pagecast Cloudflare Pages URL.",
   "author": {
     "name": "Pagecast"

--- a/plugin/skills/publish-report/SKILL.md
+++ b/plugin/skills/publish-report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: publish-report
 description: Help publish local HTML, Markdown, or built static web projects by asking whether to use Claude Code Artifacts or Pagecast/Cloudflare Pages when the user's publish request is ambiguous. Use when a report, plan, doc, dashboard, analysis, or static build output should be shared from Claude Code, especially when the user says publish, share, make a public link, or send this. If the user explicitly says Pagecast, publish with Pagecast.
-version: 0.5.0
+version: 0.6.0
 ---
 
 # Publish with Pagecast


### PR DESCRIPTION
## Summary
- bump Pagecast and package-facing components to 0.6.0
- publish agent-first Home, onboarding, Activity analytics, and telemetry changes in the changelog
- refresh upgrade, privacy, extension, and release workflow documentation

## Validation
- npm run build
- npm run check
- pnpm -C web exec tsc --noEmit
- npm test
- packed tarball install and CLI smoke
- docker build --check, image build, and offline Wrangler 4.86.0 smoke