### PR TITLE
Add Skills.sh installation support

### DIFF
--- a/.codex/skills/publish-report/SKILL.md
+++ b/.codex/skills/publish-report/SKILL.md
@@ -80,9 +80,6 @@ Add any of these to a `publish` command:
 - `--expires <7d|12h|never>` — edge-enforced link expiry (default 30d). The page
   returns 410 once expired; `--expires never` keeps it live until revoked. The
   result JSON reports `expiresAt` (or none when never).
-- `--password "<pw>"` — gate the page behind a password, enforced at the edge so
-  every file of a multi-file report is covered. `--no-password` removes protection.
-  The result JSON reports `passwordProtected: true`.
 - `--label "<name>"` — set the page's display name in the Pagecast app.
 - `--context-id "<id>"` — explicitly select the local agent context.
 - `--new-link` — force a fresh URL.
@@ -91,8 +88,15 @@ Add any of these to a `publish` command:
   authentication-required result instead.
 
 ```sh
-npx pagecast publish "/absolute/path/to/report.html" --expires 7d --password "hunter2" --json
+npx pagecast publish "/absolute/path/to/report.html" --expires 7d --label "Launch report" --json
 ```
+
+### Password handling
+
+Never ask the user to provide a page password in chat and never place a secret
+in an agent-generated command or tool argument. Publish the page first, then
+tell the user to open the local `npx pagecast` app and set password protection
+there. This keeps the credential out of the model and tool transcript.
 
 **Publishing a plan** (e.g. after plan mode): the plan lives in your context, not
 a file yet. If the user wants it shared, first write the plan markdown to a file

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ them to shareable Cloudflare Pages URLs — from the terminal or your coding age
 
 **Feature HTML:** <https://pagecasthq.pages.dev/>
 
+**Agent skill:** [install `publish-report` from Skills.sh](https://www.skills.sh/amal-david/pagecast/publish-report)
+
 <p align="center">
   <img src="media/admin.png" alt="Pagecast admin UI: published reports with per-page password protection" width="900">
 </p>
@@ -269,14 +271,17 @@ returns whether the link was created or updated. A proactive agent suggestion
 still asks once; a command-only request returns only the command.
 
 ```sh
-# Codex
+# Skills.sh (Codex, Claude Code, Cursor, Gemini CLI, and other supported agents)
+npx skills add https://github.com/amal-david/pagecast --skill publish-report
+
+# Manual Codex install from a Pagecast clone
 cp -R .codex/skills/publish-report ~/.codex/skills/
 
-# Claude Code
+# Claude Code plugin (includes the report-detection hook)
 /plugin marketplace add Amal-David/pagecast
 /plugin install pagecast@pagecast
 
-# Any other agent
+# Manual Agent-Skills install
 cp plugin/skills/publish-report/SKILL.md /path/to/your-agent/skills/publish-report/SKILL.md
 ```
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ still asks once; a command-only request returns only the command.
 npx skills add https://github.com/amal-david/pagecast --skill publish-report
 
 # Manual Codex install from a Pagecast clone
+mkdir -p ~/.codex/skills
 cp -R .codex/skills/publish-report ~/.codex/skills/
 
 # Claude Code plugin (includes the report-detection hook)

--- a/llms.txt
+++ b/llms.txt
@@ -7,12 +7,14 @@
 - Website: https://pagecasthq.pages.dev/
 - GitHub: https://github.com/Amal-David/pagecast
 - README: https://github.com/Amal-David/pagecast/blob/main/README.md
+- Skills.sh: https://www.skills.sh/amal-david/pagecast/publish-report
 - Codex skill: https://github.com/Amal-David/pagecast/tree/main/.codex/skills/publish-report
 - Portable agent skill: https://github.com/Amal-David/pagecast/blob/main/plugin/skills/publish-report/SKILL.md
 
 ## Install
 
 - One-command app: `npx pagecast`
+- Agent skill: `npx skills add https://github.com/amal-david/pagecast --skill publish-report`
 - From source: `git clone https://github.com/Amal-David/pagecast.git && cd pagecast && npm start`
 
 ## Command discovery

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -19,6 +19,17 @@ npx pagecast publish "/absolute/path/file.md" --json
 
 ### 1. Install the agent integration
 
+**Skills.sh-compatible agents** — install the public `publish-report` skill in
+one command:
+
+```sh
+npx skills add https://github.com/amal-david/pagecast --skill publish-report
+```
+
+This supports Codex, Claude Code, Cursor, Gemini CLI, and the other agents
+supported by the Skills CLI. See the
+[Pagecast listing on Skills.sh](https://www.skills.sh/amal-david/pagecast/publish-report).
+
 **Codex CLI / Codex desktop** — copy the Codex-native skill:
 
 ```sh

--- a/plugin/skills/publish-report/SKILL.md
+++ b/plugin/skills/publish-report/SKILL.md
@@ -106,9 +106,6 @@ Add any of these to a `publish` command:
 - `--expires <7d|12h|never>` — edge-enforced link expiry (default 30d). The page
   returns 410 once expired; `--expires never` keeps it live until revoked. The
   result JSON reports `expiresAt` (or none when never).
-- `--password "<pw>"` — gate the page behind a password, enforced at the edge so
-  every file of a multi-file report is covered. `--no-password` removes protection.
-  The result JSON reports `passwordProtected: true`.
 - `--label "<name>"` — set the page's display name in the Pagecast app.
 - `--context-id "<id>"` — explicitly select the local agent context.
 - `--new-link` — force a fresh URL.
@@ -117,8 +114,15 @@ Add any of these to a `publish` command:
   authentication-required result instead.
 
 ```sh
-npx pagecast publish "/absolute/path/to/report.html" --expires 7d --password "hunter2" --json
+npx pagecast publish "/absolute/path/to/report.html" --expires 7d --label "Launch report" --json
 ```
+
+### Password handling
+
+Never ask the user to provide a page password in chat and never place a secret
+in an agent-generated command or tool argument. Publish the page first, then
+tell the user to open the local `npx pagecast` app and set password protection
+there. This keeps the credential out of the model and tool transcript.
 
 **Publishing a plan** (e.g. after plan mode): the plan lives in your context, not
 a file yet. If the user wants it shared, first write the plan markdown to a file

--- a/test/skill-agent-first.test.js
+++ b/test/skill-agent-first.test.js
@@ -19,7 +19,8 @@ for (const path of [
     assert.match(skill, /"action": "created" \| "updated"/);
     assert.match(skill, /resumes automatically/i);
     assert.match(skill, /Never ask the user to provide a page password in chat/i);
-    assert.doesNotMatch(skill, /--password\s+["']/i);
+    assert.doesNotMatch(skill, /--(?:no-)?password\b/i);
+    assert.doesNotMatch(skill, /["'](?:password|passwordProtected)["']\s*:/i);
     assert.doesNotMatch(skill, /hunter2/i);
     assert.doesNotMatch(skill, /re-running `publish` (?:mints|creates) a new link/i);
   });

--- a/test/skill-agent-first.test.js
+++ b/test/skill-agent-first.test.js
@@ -18,6 +18,9 @@ for (const path of [
     assert.match(skill, /--update/);
     assert.match(skill, /"action": "created" \| "updated"/);
     assert.match(skill, /resumes automatically/i);
+    assert.match(skill, /Never ask the user to provide a page password in chat/i);
+    assert.doesNotMatch(skill, /--password\s+["']/i);
+    assert.doesNotMatch(skill, /hunter2/i);
     assert.doesNotMatch(skill, /re-running `publish` (?:mints|creates) a new link/i);
   });
 }


### PR DESCRIPTION
## Summary

- document the one-command Skills.sh install path in the main and plugin READMEs
- expose the live Skills.sh listing to agents through llms.txt
- keep page passwords out of agent-generated commands so the catalog security audit can pass on refresh
- add regression coverage for the password-handling instruction

## Verification

- npx skills add Amal-David/pagecast --list
- isolated public GitHub install into a temporary Codex project
- isolated local-branch install into a temporary Codex project
- npm test (389 tests passed)
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Skills.sh installation instructions for the `publish-report` capability across the README, agent documentation, and plugin guide.
  * Updated publishing guidance to remove inline password options and direct users to configure password protection afterward in the local Pagecast app.
  * Added a streamlined installation command for Skills.sh-compatible agents.

* **Tests**
  * Added checks to ensure publishing guidance does not request passwords or include password command options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->