### PR TITLE
Repair telemetry and Activity setup

### DIFF
--- a/src/pagecast-home.js
+++ b/src/pagecast-home.js
@@ -182,17 +182,6 @@ async function initializeUnderLease({ dataDir, workspaceDataDir, cwd }) {
   const registry = await readJson(registryPath, { version: 1, workspaces: [] });
   registry.version = 1;
   registry.workspaces = Array.isArray(registry.workspaces) ? registry.workspaces : [];
-  const registered = registry.workspaces.find((entry) => entry.id === workspace.id);
-  if (registered) {
-    return {
-      dataDir,
-      workspaceDataDir,
-      workspaceId: workspace.id,
-      imported: false,
-      mode: registered.mode || "home"
-    };
-  }
-
   const legacyConfigPath = path.join(workspaceDataDir, CONFIG_FILE);
   const legacyReportsPath = path.join(workspaceDataDir, REPORT_STATE_FILE);
   const legacyOwnerPath = path.join(workspaceDataDir, PUBLISHER_OWNER_FILE);
@@ -207,6 +196,34 @@ async function initializeUnderLease({ dataDir, workspaceDataDir, cwd }) {
   const mode = homeTarget && legacyTarget && !sameTarget(homeTarget, legacyTarget)
     ? "legacy-target"
     : "home";
+
+  // Feedback resources are account-scoped, not Pages-project-scoped. A legacy
+  // workspace may therefore hold the only copy of the Worker credentials even
+  // when its Pages project is quarantined from Home. Adopt only that feedback
+  // block, and only when both profiles name the same Cloudflare account.
+  if (
+    homeConfig &&
+    !homeConfig.feedback &&
+    legacyConfig?.feedback &&
+    homeTarget?.accountId &&
+    homeTarget.accountId === legacyTarget?.accountId
+  ) {
+    await atomicWriteJson(homeConfigPath, {
+      ...homeConfig,
+      feedback: structuredClone(legacyConfig.feedback)
+    });
+  }
+
+  const registered = registry.workspaces.find((entry) => entry.id === workspace.id);
+  if (registered) {
+    return {
+      dataDir,
+      workspaceDataDir,
+      workspaceId: workspace.id,
+      imported: false,
+      mode: registered.mode || "home"
+    };
+  }
 
   if (!homeHasConfig && legacyConfig) {
     await atomicWriteJson(homeConfigPath, legacyConfig);

--- a/src/wrangler-gateway.js
+++ b/src/wrangler-gateway.js
@@ -853,9 +853,23 @@ export function createCloudflareAuthManager({
         // Continue to the create attempt when listing is unavailable.
       }
       if (!d1Id) {
-        d1Id = parseD1DatabaseId(
-          await runWrangler(["d1", "create", databaseName, "--json"], timeoutMs, env)
-        );
+        let createOutput;
+        try {
+          createOutput = await runWrangler(
+            ["d1", "create", databaseName, "--json"],
+            timeoutMs,
+            env
+          );
+        } catch (error) {
+          if (!/unknown argument:\s*json|unknown option.*--json/i.test(stripAnsi(error.message || ""))) {
+            throw error;
+          }
+          // Wrangler versions including Pagecast's pinned 4.86 support JSON
+          // for `d1 list` but not `d1 create`. Their text output includes the
+          // same database_id, which parseD1DatabaseId already handles.
+          createOutput = await runWrangler(["d1", "create", databaseName], timeoutMs, env);
+        }
+        d1Id = parseD1DatabaseId(createOutput);
       }
       if (!d1Id) throw appError("Could not create the Pagecast analytics D1 database.", 502);
 

--- a/telemetry/worker.js
+++ b/telemetry/worker.js
@@ -23,6 +23,10 @@ export const COMMAND_ALLOWLIST = [
   "pages",
   "feedback",
   "goal",
+  "background",
+  "local-url",
+  "setup-local-url",
+  "open",
   "telemetry",
   "help",
   "version",
@@ -32,6 +36,8 @@ const SUBCOMMAND_ALLOWLIST = {
   pages: ["setup", "status", "projects", "deploy", "deployments"],
   feedback: ["setup", "status"],
   goal: ["publish", "status", "stop"],
+  background: ["start", "stop", "status", "service"],
+  "local-url": ["install", "remove", "status", "setup", "uninstall"],
   telemetry: ["status", "enable", "disable"]
 };
 const OUTCOME_ALLOWLIST = ["started", "success", "error"];

--- a/test/pagecast-home.test.js
+++ b/test/pagecast-home.test.js
@@ -152,5 +152,53 @@ test("a workspace on another Cloudflare project is registered as legacy and neve
   assert.equal(secondEntry.mode, "legacy-target");
   assert.equal(secondEntry.legacyTarget.projectName, "other-project");
 
+  // A previously registered legacy workspace can later supply the only copy
+  // of account-scoped feedback credentials without changing Home's Pages target.
+  const secondConfigPath = path.join(secondCwd, ".pagecast", "config.json");
+  const secondConfig = JSON.parse(await fs.readFile(secondConfigPath, "utf8"));
+  secondConfig.feedback = {
+    url: "https://pagecast-feedback.example.workers.dev",
+    workerName: "pagecast-feedback",
+    kvId: "legacy-kv-id",
+    statsToken: "preserved-stats-token"
+  };
+  await fs.writeFile(secondConfigPath, JSON.stringify(secondConfig));
+  const registeredRerun = await initializePagecastHome({ homeDir, cwd: secondCwd });
+  assert.equal(registeredRerun.imported, false);
+
+  const mergedConfig = JSON.parse(await fs.readFile(path.join(first.dataDir, "config.json"), "utf8"));
+  assert.equal(mergedConfig.pages.projectName, "primary-home");
+  assert.deepEqual(mergedConfig.feedback, secondConfig.feedback);
+
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+test("legacy feedback credentials never cross Cloudflare account boundaries", async () => {
+  const root = await tempRoot();
+  const homeDir = path.join(root, "user");
+  const primaryCwd = path.join(root, "primary");
+  const foreignCwd = path.join(root, "foreign");
+
+  for (const [cwd, accountId, feedback] of [
+    [primaryCwd, "a".repeat(32), null],
+    [foreignCwd, "b".repeat(32), { statsToken: "must-not-cross-accounts" }]
+  ]) {
+    const legacy = path.join(cwd, ".pagecast");
+    await fs.mkdir(legacy, { recursive: true });
+    await fs.writeFile(path.join(legacy, "config.json"), JSON.stringify({
+      pages: { accountId, projectName: `${path.basename(cwd)}-project` },
+      feedback
+    }));
+    await fs.writeFile(
+      path.join(legacy, "reports.json"),
+      JSON.stringify({ version: 4, reports: [], redirects: [], operations: [], pendingDeletions: [] })
+    );
+  }
+
+  const primary = await initializePagecastHome({ homeDir, cwd: primaryCwd });
+  await initializePagecastHome({ homeDir, cwd: foreignCwd });
+  const config = JSON.parse(await fs.readFile(path.join(primary.dataDir, "config.json"), "utf8"));
+  assert.equal(config.feedback, null);
+
   await fs.rm(root, { recursive: true, force: true });
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -4760,6 +4760,49 @@ test("setupFeedback creates KV, deploys the worker, and returns the url", async 
   await fs.rm(deployDir, { recursive: true, force: true });
 });
 
+test("setupFeedback falls back when Wrangler d1 create does not support --json", async () => {
+  const calls = [];
+  const { fakeSpawn } = makeWranglerFake((args) => {
+    const line = args.join(" ");
+    calls.push(line);
+    if (line.includes("kv namespace list")) return { code: 0, output: "[]" };
+    if (line.includes("d1 list")) return { code: 0, output: "[]" };
+    if (line.includes("d1 create") && line.includes("--json")) {
+      return { code: 1, output: "Unknown argument: json", stderr: true };
+    }
+    if (line.includes("d1 create")) {
+      return {
+        code: 0,
+        output: 'database_id = "11111111-2222-4333-8444-555555555555"'
+      };
+    }
+    if (line.includes("d1 execute")) return { code: 0, output: "ok" };
+    if (line.includes("deploy")) {
+      return { code: 0, output: "https://pagecast-feedback.acme.workers.dev" };
+    }
+    return { code: 0, output: "" };
+  });
+
+  const manager = createCloudflareAuthManager({ spawnImpl: fakeSpawn });
+  const deployDir = await fs.mkdtemp(path.join(os.tmpdir(), "pagecast-d1-fallback-"));
+  try {
+    const result = await manager.setupFeedback({
+      workerSource: "export default {}",
+      statsToken: "stats",
+      visitorSecret: "visitor",
+      reactionsEnabled: false,
+      deployDir
+    });
+    assert.equal(result.d1Id, "11111111-2222-4333-8444-555555555555");
+    assert.ok(calls.some((line) => line.includes("d1 create pagecast-feedback-analytics --json")));
+    assert.ok(calls.some(
+      (line) => line.includes("d1 create pagecast-feedback-analytics") && !line.includes("--json")
+    ));
+  } finally {
+    await fs.rm(deployDir, { recursive: true, force: true });
+  }
+});
+
 test("setupFeedback deploys with a relative --config from deployDir (space-safe under shell)", async () => {
   // Regression: with shell:true on Windows (needed to spawn the npx .cmd shim),
   // cmd.exe splits an unquoted absolute --config path on spaces. The deploy must

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -186,6 +186,27 @@ test("worker rejects non-allowlisted commands and subcommands", () => {
   assert.equal(cleanAnonId("not-an-id"), "");
 });
 
+test("worker accepts every command shape emitted by the current CLI", () => {
+  for (const argv of [
+    [],
+    ["publish"],
+    ["pages", "deploy"],
+    ["feedback", "status"],
+    ["goal", "publish"],
+    ["background", "service"],
+    ["local-url", "install"],
+    ["setup-local-url"],
+    ["open"],
+    ["telemetry", "status"],
+    ["--help"],
+    ["--version"],
+    ["not-a-command"]
+  ]) {
+    const classification = classifyCommand(argv);
+    assert.ok(buildDataPoint(classification), `worker rejected ${JSON.stringify(classification)}`);
+  }
+});
+
 test("worker platform validators allowlist os/arch and shape version/node", () => {
   const OS = ["darwin", "linux", "win32"];
   assert.equal(cleanEnum("darwin", OS), "darwin");

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -199,12 +199,19 @@ test("worker accepts every command shape emitted by the current CLI", () => {
     ["open"],
     ["telemetry", "status"],
     ["--help"],
-    ["--version"],
-    ["not-a-command"]
+    ["--version"]
   ]) {
     const classification = classifyCommand(argv);
     assert.ok(buildDataPoint(classification), `worker rejected ${JSON.stringify(classification)}`);
   }
+});
+
+test("worker accepts the anonymized unknown classification without retaining raw input", () => {
+  const classification = classifyCommand(["not-a-command"]);
+  assert.deepEqual(classification, { command: "unknown" });
+  const dataPoint = buildDataPoint(classification);
+  assert.deepEqual(dataPoint.indexes, ["unknown"]);
+  assert.ok(!JSON.stringify(dataPoint).includes("not-a-command"));
 });
 
 test("worker platform validators allowlist os/arch and shape version/node", () => {


### PR DESCRIPTION
Preserves same-account legacy Activity credentials during Home migration, supports Wrangler versions that reject d1 create --json, and keeps telemetry ingestion allowlists aligned with the current CLI. Production Activity setup completed for all four current managed publications; focused syntax, security, analytics, server, Home, feedback, and telemetry tests pass (166/166).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved eligible legacy feedback credentials during Home configuration migration.
  * Prevented feedback credentials from being copied across Cloudflare account boundaries.
  * Improved D1 analytics provisioning when Wrangler does not support `d1 create --json`.
* **Telemetry**
  * Expanded worker command handling to include background, local URL, setup-local-URL, and open.
* **Tests**
  * Added integration and worker validation tests covering the updated D1 and command handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->