### PR TITLE
Release Pagecast v0.6.1

### DIFF
--- a/.codex/skills/publish-report/SKILL.md
+++ b/.codex/skills/publish-report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: publish-report
 description: Publish local HTML, Markdown, or built static web projects with Pagecast as shareable public URLs. Use whenever Codex creates or finishes an .html, .htm, .md, .markdown, or static build output that a person could share (a report, plan, doc, dashboard, or analysis) — proactively offer to publish it without being asked — and whenever the user asks to publish, share, make a public link for, or send a local report/doc/dashboard/web project from terminal, Codex CLI, or Codex desktop.
-version: 0.6.0
+version: 0.6.1
 ---
 
 # Publish with Pagecast

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Expected package version (for example 0.6.0 or v0.6.0)
+        description: Expected package version (for example 0.6.1 or v0.6.1)
         required: true
         type: string
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to Pagecast are documented here. This project follows
 
 ## Unreleased
 
+## 0.6.1 — 2026-07-21
+
+### Added
+
+- **Skills.sh installation support** — the packaged publishing skill now has a
+  one-command install path and agent-readable catalog guidance.
+- **Real Settings navigation and Analytics destination** — Settings sidebar
+  items open their actual sections, analytics uses the saved configuration, and
+  page actions remain available on one row.
+
+### Fixed
+
+- **Activity credential migration** — compatible legacy feedback credentials
+  move into Pagecast Home only when both Pages targets use the same Cloudflare
+  account.
+- **Wrangler D1 provisioning compatibility** — Activity setup retries without
+  `--json` when the installed Wrangler version rejects that option.
+- **Telemetry command coverage** — ingestion accepts the current CLI's
+  background, local URL, setup, and open command classifications while keeping
+  unknown command input anonymized.
+
 ## 0.6.0 — 2026-07-14
 
 ### Added

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -38,7 +38,7 @@ pagecast telemetry disable
 | `command` | `publish`, `pages`, `serve` | Which feature is used |
 | `subcommand` | `deploy`, `status` (allowlisted only) | Which sub-feature is used |
 | `outcome` | `started` | Reserved for success/error signal |
-| `version` | `0.6.0` | Which release is in the field |
+| `version` | `0.6.1` | Which release is in the field |
 | `os`/`arch` | `darwin` / `arm64` | Which platforms to support |
 | `node` | `v22.22.3` | Which Node versions to support |
 | `anonId` | random 32-character hex | Coarse distinct-install counting |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npx pagecast pages setup --project your-pagecast-home
 ```
 
 **Upgrading from 0.5:** stop the old process (`npx pagecast@0.5.0 background stop`),
-reinstall the macOS login service if you use it (`npx pagecast@0.6.0 background
+reinstall the macOS login service if you use it (`npx pagecast@0.6.1 background
 service install`), and reload the unpacked Chrome extension from the matching
 release. The first 0.6 launch creates `~/.pagecast/home/` and imports compatible
 workspace publications without changing URLs; publications on other Cloudflare

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pagecast — Local to Public",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvppHjQcznEeTBkKJU4f6zI+oWt3Z0YH7L+jFbLQ1EsbwKJd9pCyjded9XbC+cITveMupy5yeI424Zs7fKJCUgXMy2OKjRl8ZuNaLC8R3mPTPlgAAnFoZNvo/cSEvnvLi/A/yYPsRPJKT2fXCEIHNyTaXPzBmh30ij4MxVxb3ugNQFu/UKQ07LqAD0M0iDKqC5as9mDvQBi0vo1BgtSLHqJzfWcyWR5lNdLoRD4hUTPsd3I0lrXmrrRa6YYc/L/sYxiIJ1NdZMNnMRr5QUMSkmVZaaGZnVUQB7+ItdoU2duxDsqKo4ljf/yj/lPaCBnNbHp0zD4d/c3OeGG+OZEtUswIDAQAB",
   "description": "Turn a local HTML or Markdown file open in your browser into a public link, via your running Pagecast server.",
   "action": {

--- a/extension/store/SUBMIT.md
+++ b/extension/store/SUBMIT.md
@@ -31,7 +31,7 @@ This zips the extension WITHOUT the `store/` assets and dotfiles. Upload
 `pagecast-extension-v<VERSION>.zip` in the dashboard ("Package" → "Upload new
 package"). Tagged GitHub releases read the same manifest version and use the
 same `pagecast-extension-v<VERSION>.zip` convention, for example
-`pagecast-extension-v0.6.0.zip`.
+`pagecast-extension-v0.6.1.zip`.
 
 ## 3. Privacy practices answers (Web Store form)
 
@@ -62,7 +62,7 @@ same `pagecast-extension-v<VERSION>.zip` convention, for example
 ## 5. Before you submit
 
 - Confirm `extension/manifest.json` matches the npm package and plugin release
-  version. For v0.6 all package-facing metadata is `0.6.0`.
+  version. For this release all package-facing metadata is `0.6.1`.
 - Replace the placeholder developer/brand details as needed.
 - One-time: a Chrome Web Store **developer account** ($5 registration).
 - Test the packaged zip via Load unpacked once more (`chrome://extensions`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagecast",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "description": "Preview local HTML reports and static mini apps, then publish them to shareable URLs.",
   "license": "MIT",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pagecast",
   "displayName": "Pagecast",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "When your agent finishes an HTML or Markdown report, plan, or doc, it asks whether to publish it as a Claude Code Artifact or as a Pagecast Cloudflare Pages URL.",
   "author": {
     "name": "Pagecast"

--- a/plugin/skills/publish-report/SKILL.md
+++ b/plugin/skills/publish-report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: publish-report
 description: Help publish local HTML, Markdown, or built static web projects by asking whether to use Claude Code Artifacts or Pagecast/Cloudflare Pages when the user's publish request is ambiguous. Use when a report, plan, doc, dashboard, analysis, or static build output should be shared from Claude Code, especially when the user says publish, share, make a public link, or send this. If the user explicitly says Pagecast, publish with Pagecast.
-version: 0.6.0
+version: 0.6.1
 ---
 
 # Publish with Pagecast


### PR DESCRIPTION
## Summary\n\n- bump all package-facing metadata to 0.6.1\n- document merged Skills.sh, Settings/Analytics, Activity, Wrangler, and telemetry fixes\n- prepare npm, GHCR, and Chrome extension release artifacts\n\n## Verification\n\n- npm run build\n- npm run check\n- pnpm -C web exec tsc --noEmit\n- npm test (396 passing)\n- packed tarball install/import, CLI help, and version smoke\n- Docker check deferred to release CI because the local Docker daemon is not running