### PR TITLE
Release Pagecast v0.7.0

### DIFF
--- a/.codex/skills/publish-report/SKILL.md
+++ b/.codex/skills/publish-report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: publish-report
 description: Publish local HTML, Markdown, or built static web projects with Pagecast as shareable public URLs. Use whenever Codex creates or finishes an .html, .htm, .md, .markdown, or static build output that a person could share (a report, plan, doc, dashboard, or analysis) — proactively offer to publish it without being asked — and whenever the user asks to publish, share, make a public link for, or send a local report/doc/dashboard/web project from terminal, Codex CLI, or Codex desktop.
-version: 0.6.1
+version: 0.7.0
 ---
 
 # Publish with Pagecast

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Expected package version (for example 0.6.1 or v0.6.1)
+        description: Expected package version (for example 0.7.0 or v0.7.0)
         required: true
         type: string
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to Pagecast are documented here. This project follows
 
 ## Unreleased
 
+## 0.7.0 — 2026-08-02
+
 ### Added
 
 - **Per-page Open Graph card images** — publishing now renders a 1200×630

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -38,7 +38,7 @@ pagecast telemetry disable
 | `command` | `publish`, `pages`, `serve` | Which feature is used |
 | `subcommand` | `deploy`, `status` (allowlisted only) | Which sub-feature is used |
 | `outcome` | `started` | Reserved for success/error signal |
-| `version` | `0.6.1` | Which release is in the field |
+| `version` | `0.7.0` | Which release is in the field |
 | `os`/`arch` | `darwin` / `arm64` | Which platforms to support |
 | `node` | `v22.22.3` | Which Node versions to support |
 | `anonId` | random 32-character hex | Coarse distinct-install counting |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npx pagecast pages setup --project your-pagecast-home
 ```
 
 **Upgrading from 0.5:** stop the old process (`npx pagecast@0.5.0 background stop`),
-reinstall the macOS login service if you use it (`npx pagecast@0.6.1 background
+reinstall the macOS login service if you use it (`npx pagecast@0.7.0 background
 service install`), and reload the unpacked Chrome extension from the matching
 release. The first 0.6 launch creates `~/.pagecast/home/` and imports compatible
 workspace publications without changing URLs; publications on other Cloudflare

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pagecast — Local to Public",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvppHjQcznEeTBkKJU4f6zI+oWt3Z0YH7L+jFbLQ1EsbwKJd9pCyjded9XbC+cITveMupy5yeI424Zs7fKJCUgXMy2OKjRl8ZuNaLC8R3mPTPlgAAnFoZNvo/cSEvnvLi/A/yYPsRPJKT2fXCEIHNyTaXPzBmh30ij4MxVxb3ugNQFu/UKQ07LqAD0M0iDKqC5as9mDvQBi0vo1BgtSLHqJzfWcyWR5lNdLoRD4hUTPsd3I0lrXmrrRa6YYc/L/sYxiIJ1NdZMNnMRr5QUMSkmVZaaGZnVUQB7+ItdoU2duxDsqKo4ljf/yj/lPaCBnNbHp0zD4d/c3OeGG+OZEtUswIDAQAB",
   "description": "Turn a local HTML or Markdown file open in your browser into a public link, via your running Pagecast server.",
   "action": {

--- a/extension/store/SUBMIT.md
+++ b/extension/store/SUBMIT.md
@@ -31,7 +31,7 @@ This zips the extension WITHOUT the `store/` assets and dotfiles. Upload
 `pagecast-extension-v<VERSION>.zip` in the dashboard ("Package" → "Upload new
 package"). Tagged GitHub releases read the same manifest version and use the
 same `pagecast-extension-v<VERSION>.zip` convention, for example
-`pagecast-extension-v0.6.1.zip`.
+`pagecast-extension-v0.7.0.zip`.
 
 ## 3. Privacy practices answers (Web Store form)
 
@@ -62,7 +62,7 @@ same `pagecast-extension-v<VERSION>.zip` convention, for example
 ## 5. Before you submit
 
 - Confirm `extension/manifest.json` matches the npm package and plugin release
-  version. For this release all package-facing metadata is `0.6.1`.
+  version. For this release all package-facing metadata is `0.7.0`.
 - Replace the placeholder developer/brand details as needed.
 - One-time: a Chrome Web Store **developer account** ($5 registration).
 - Test the packaged zip via Load unpacked once more (`chrome://extensions`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pagecast",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pagecast",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@resvg/resvg-wasm": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagecast",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "type": "module",
   "description": "Preview local HTML reports and static mini apps, then publish them to shareable URLs.",
   "license": "MIT",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pagecast",
   "displayName": "Pagecast",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "When your agent finishes an HTML or Markdown report, plan, or doc, it asks whether to publish it as a Claude Code Artifact or as a Pagecast Cloudflare Pages URL.",
   "author": {
     "name": "Pagecast"

--- a/plugin/skills/publish-report/SKILL.md
+++ b/plugin/skills/publish-report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: publish-report
 description: Help publish local HTML, Markdown, or built static web projects by asking whether to use Claude Code Artifacts or Pagecast/Cloudflare Pages when the user's publish request is ambiguous. Use when a report, plan, doc, dashboard, analysis, or static build output should be shared from Claude Code, especially when the user says publish, share, make a public link, or send this. If the user explicitly says Pagecast, publish with Pagecast.
-version: 0.6.1
+version: 0.7.0
 ---
 
 # Publish with Pagecast


### PR DESCRIPTION
Version bump to 0.7.0 across package.json, extension manifest, plugin manifest, both publish-report skills, lockfile, and doc version strings. CHANGELOG promotes the Unreleased entry:

- **Per-page Open Graph card images** — publish renders a 1200×630 card from the page's own title/description locally (satori + `@resvg/resvg-wasm`, the package's first runtime dependencies) and deploys it with the snapshot on the user's own Pages project. Shipped in #26.

Minor bump per semver: new feature + new runtime dependencies.

`npm run check` and full test suite (403/403) pass locally.

After merge: `gh release create v0.7.0` publishes to npm (provenance), GHCR image, and attaches the extension zip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the product, extension, plugin, and publishing skill to version **0.7.0**.
  * Added release notes and updated release metadata for version 0.7.0.

* **Documentation**
  * Updated installation, telemetry, submission, and manual release instructions to reference version 0.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->