### PR TITLE
Install runtime deps in the npm publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,11 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      # The test suite exercised by the publish hooks needs the package's
+      # runtime dependencies installed (frozen lockfile, no lifecycle scripts).
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
       # `npm publish` runs the package's prepack/prepublishOnly hooks, which build
       # the web UI (pnpm, frozen lockfile) and run `npm run check` + `npm test`.
       # A failing build/check/test blocks the publish.


### PR DESCRIPTION
The v0.7.0 release run failed only in the "Publish npm package" job: `npm publish` runs `prepublishOnly` (check + tests), and the og-card tests need satori/resvg installed — the job had no install step (the verify job got one in #26, the npm job was missed). Adds `npm ci --ignore-scripts` before publish.

After merge, the plan is to publish 0.7.0 via `workflow_dispatch` from main (the release-event jobs for Docker and the extension zip already succeeded for v0.7.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release publishing process to install dependencies more reliably before publishing packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->